### PR TITLE
Fix broken NEAR account listing

### DIFF
--- a/.changeset/fix-near-account-list.md
+++ b/.changeset/fix-near-account-list.md
@@ -1,0 +1,5 @@
+---
+"better-near-auth": minor
+---
+
+Expose active and available NEAR account state from `listAccounts` and add `setPrimaryAccount` for selecting the active account.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# better-near-auth — Agent Guide
+
+## Commands
+```
+pnpm build          # tsc → dist/index.js + dist/client.js (ESM)
+pnpm typecheck      # tsc --noEmit (same as lint)
+pnpm test           # vitest (mocked, no chain needed)
+pnpm lint           # alias for typecheck
+pnpm changeset      # add changeset for release
+pnpm release        # build + changeset publish
+```
+**Order**: `pnpm build` (if src changed) → `pnpm typecheck` → `pnpm test`
+
+## Key facts
+- Single npm package (`better-near-auth`), pnpm workspace only for examples
+- Server plugin: `import { siwn } from "better-near-auth"` (src/index.ts)
+- Client plugin: `import { siwnClient } from "better-near-auth/client"` (src/client.ts)
+- Exports conform to Better Auth plugin convention (default + `/client` subpath)
+- Tests in `src/near.test.ts` — excluded from tsconfig, not typechecked. Must run separately via `pnpm test`
+- Lockfile: `pnpm-lock.yaml` (maintain with `pnpm install --frozen-lockfile` in CI)
+- Requires Node >=24, pnpm 10.30.3
+- Packages are ESM with `"type": "module"`, imports use `.js` extensions (`verbatimModuleSyntax`)
+- No formatter (no prettier/eslint) — only tsc for quality
+
+## Source layout
+```
+src/index.ts    — SIWN plugin (endpoints: nonce, verify, relay, profile, link, view, etc.)
+src/client.ts   — SIWN client plugin (near wallet connect, sign, delegate actions)
+src/types.ts    — Zod schemas + TS types (AccountId, nonce/verify/relay request types)
+src/schema.ts   — DB schema (3 models: nearAccount, relayedTransaction, relayerKey)
+src/profile.ts  — Profile lookup (FastNear KV → NEAR Social fallback)
+src/utils.ts    — AES-256-GCM encrypt/decrypt for relayer key, hex/base64 helpers
+src/near.test.ts — Vitest tests (mocked near-kit, no chain needed)
+```
+
+## DB models (Better Auth plugin schema)
+- **nearAccount**: maps NEAR account to user (accountId, network, publicKey, isPrimary)
+- **relayedTransaction**: tracks on-chain tx (txHash, senderId, receiverId, status)
+- **relayerKey**: singleton per network — encrypted ED25519 private key (AES-256-GCM)
+
+## Architecture
+- Uses `near-kit` for NEAR RPC/tx/wallet and `@hot-labs/near-connect` for browser wallet
+- Auth flow: wallet signs NEP-413 message → server verifies via `verifyNep413Signature` → session created
+- Relayer: wraps user's signed delegate action in a tx signed by relayer key → broadcasts on-chain
+- Two relayer modes: **ephemeral** (auto-generated key, encrypted in DB) and **explicit** (configured accountId + privateKey)
+- Relayer key encryption: HKDF-SHA256 from `BETTER_AUTH_SECRET` + AES-256-GCM
+- Profile: FastNear KV → `api.near.social` fallback
+- Network detection: accounts ending `.testnet` → testnet, everything else → mainnet
+- Email: `.near` accounts get `localpart@near.email`, non-`.near` accounts get no email
+- Client state management via `nanostores` (not React state)
+- SDK endpoints all under `/near/*` prefix
+- `near.listAccounts()` returns `{ accounts, activeAccount, availableAccounts }`; active means `isPrimary`, available means selectable non-active NEAR accounts
+- `near.setPrimaryAccount({ accountId, network? })` updates `isPrimary` and should be used when switching the active NEAR account
+
+## Release (changesets)
+- `pnpm changeset` → select `better-near-auth`, bump type, write summary
+- CI on main merges creates "Version Packages" PR automatically
+- `pnpm release` publishes to npm (CI only; requires NPM_TOKEN)
+
+## Style conventions
+- No code comments
+- Use `satisfies BetterAuthPlugin` / `satisfies BetterAuthClientPlugin`
+- All imports use `.js` extensions (ESM)
+- Zod schemas defined in types.ts, re-exported via `export * from "./types.js"`
+
+## Test conventions
+- Uses `getTestInstance` from `better-auth/test` — in-memory DB, full Better Auth server
+- `disableTestUser: true` for tests that create users via SIWN flow
+- near-kit is fully mocked — no real RPC or wallet needed
+- Nonce endpoints validated against `AccountIdSchema` from `near-kit/schemas`
+- For protected SIWN endpoints after `/near/verify`, use `customFetchImpl` with the returned session cookie when the generated test client does not preserve auth state
+
+## CI workflows (`.github/workflows/`)
+- `release.yml` — changesets auto-release on main
+- `deploy-example.yml` — deploys `auth.everything.dev` example
+- `check-skills.yml` — validates TanStack intent skills artifacts
+- `update-example-version.yml` — updates `browser-2-server` example on release

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ const aliceProfile = await authClient.near.getProfile("alice.near");
 
 ```ts
 const accountId = authClient.near.getAccountId();
+const { data } = await authClient.near.listAccounts();
+const activeAccount = data?.activeAccount;
+const availableAccounts = data?.availableAccounts ?? [];
+await authClient.near.setPrimaryAccount({ accountId: "alice.near", network: "mainnet" });
 await authClient.near.disconnect();
 ```
 
@@ -248,7 +252,8 @@ When `accountId` and `privateKey` are omitted, the relayer starts in **ephemeral
 - `disconnect()` — Disconnect wallet and clear cached data
 - `link(callbacks?)` — Link a NEAR account to the current session
 - `unlink(params)` — Unlink a NEAR account
-- `listAccounts()` — List all linked NEAR accounts
+- `listAccounts()` — List linked NEAR accounts with `activeAccount` and `availableAccounts`
+- `setPrimaryAccount(params)` — Select the active NEAR account for the session user
 
 **Relay**
 - `buildSignedDelegateAction(receiverId, buildActions)` — Build + sign a delegate action via wallet FAK

--- a/examples/auth.everything.dev/bos.config.json
+++ b/examples/auth.everything.dev/bos.config.json
@@ -38,8 +38,8 @@
         "shareScope": "default"
       },
       "better-near-auth": {
-        "version": "^1.4.2",
-        "requiredVersion": "^^1.4.2",
+        "version": "1.4.2",
+        "requiredVersion": "^1.4.2",
         "singleton": true,
         "strictVersion": false,
         "shareScope": "default"

--- a/examples/auth.everything.dev/package.json
+++ b/examples/auth.everything.dev/package.json
@@ -18,7 +18,7 @@
       "better-auth": "1.6.9",
       "@better-auth/api-key": "1.6.9",
       "@better-auth/passkey": "1.6.9",
-      "better-near-auth": "^1.4.2",
+      "better-near-auth": "1.4.2",
       "every-plugin": "^2.5.8",
       "typescript": "^5.9.3",
       "vitest": "^4.0.17",

--- a/examples/auth.everything.dev/ui/src/lib/auth-utils.ts
+++ b/examples/auth.everything.dev/ui/src/lib/auth-utils.ts
@@ -1,12 +1,18 @@
 /**
  * Extract NEAR accountId from linked accounts
  */
+function getProviderId(account: any): string | null {
+  return typeof account?.providerId === "string" && account.providerId.length > 0
+    ? account.providerId
+    : null;
+}
+
 export function getNearAccountId(linkedAccounts: any[]): string | null {
   if (!Array.isArray(linkedAccounts)) {
     return null;
   }
-  const nearAccount = linkedAccounts.find((account) => account.providerId === "siwn");
-  return nearAccount?.accountId?.split(":")[0] || nearAccount?.providerId || null;
+  const nearAccount = linkedAccounts.find((account) => getProviderId(account) === "siwn");
+  return nearAccount?.accountId?.split(":")[0] || null;
 }
 
 /**
@@ -16,7 +22,7 @@ export function getLinkedProviders(linkedAccounts: any[]): string[] {
   if (!Array.isArray(linkedAccounts)) {
     return [];
   }
-  return linkedAccounts.map((account) => account.providerId);
+  return linkedAccounts.map((account) => getProviderId(account) ?? "unknown");
 }
 
 /**

--- a/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/home.tsx
+++ b/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/home.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useRouter } from "@tanstack/react-router";
 import {
   Check,
   CheckCircle2,
@@ -85,6 +85,10 @@ function relayerExplorerUrl(accountId: string): string {
   return `https://near.rocks/account/${accountId}`;
 }
 
+function getAccountProviderId(account: any): string {
+  return account?.providerId ?? (account?.accountId ? "siwn" : "unknown");
+}
+
 export const Route = createFileRoute("/_layout/_authenticated/home")({
   head: () => ({
     meta: [
@@ -100,16 +104,22 @@ function DashboardPage() {
   const { data: session } = useQuery<SessionData | null>(sessionQueryOptions(auth));
   const user = session?.user ?? null;
 
-  const { data: linkedAccounts = [] } = useQuery({
+  const { data: nearAccountsData = { accounts: [], activeAccount: null } } = useQuery({
     queryKey: ["near-accounts"],
     queryFn: async () => {
       const res = await auth.near.listAccounts();
-      return Array.isArray(res?.data) ? res.data : [];
+      const data = res?.data as any;
+      return {
+        accounts: Array.isArray(data?.accounts) ? data.accounts : [],
+        activeAccount: data?.activeAccount ?? null,
+      };
     },
     enabled: !!session?.user,
   });
 
-  const nearAccountId = getNearAccountId(linkedAccounts);
+  const linkedAccounts = nearAccountsData.accounts;
+  const activeNearAccount = nearAccountsData.activeAccount;
+  const nearAccountId = activeNearAccount?.accountId ?? getNearAccountId(linkedAccounts);
   const linkedProviders = getLinkedProviders(linkedAccounts);
 
   const apiClient = useApiClient();
@@ -512,6 +522,7 @@ function RelayerCard() {
 function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; user: any }) {
   const auth = useAuthClient();
   const queryClient = useQueryClient();
+  const router = useRouter();
   const [isLinkingGoogle, setIsLinkingGoogle] = useState(false);
   const [isLinkingGitHub, setIsLinkingGitHub] = useState(false);
   const [isProcessingNear, setIsProcessingNear] = useState(false);
@@ -526,8 +537,9 @@ function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; u
   const accounts = linkedAccounts;
 
   const invalidateAccounts = () => {
-    queryClient.invalidateQueries({ queryKey: ["near-accounts"] });
-    queryClient.invalidateQueries({ queryKey: ["session"] });
+    void queryClient.invalidateQueries({ queryKey: ["near-accounts"] });
+    void queryClient.invalidateQueries({ queryKey: ["session"] });
+    void router.invalidate();
   };
 
   const handleLinkSocial = async (providerId: "google" | "github") => {
@@ -586,10 +598,13 @@ function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; u
   const handleUnlinkNearAccount = async (account: any) => {
     setIsUnlinking(account.accountId);
     try {
-      const [accountId, network] = account.accountId.split(":");
+      const [accountId, fallbackNetwork] = account.accountId.split(":");
       const response = await auth.near.unlink({
         accountId,
-        network: (network as "mainnet" | "testnet") || "mainnet",
+        network:
+          (account.network as "mainnet" | "testnet") ||
+          (fallbackNetwork as "mainnet" | "testnet") ||
+          "mainnet",
       });
       if (response.data?.success) {
         toast.success("NEAR account unlinked successfully");
@@ -600,6 +615,27 @@ function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; u
     } catch (error) {
       console.error("Failed to unlink NEAR account:", error);
       toast.error("Failed to unlink NEAR account");
+    } finally {
+      setIsUnlinking(null);
+    }
+  };
+
+  const handleSetPrimaryNearAccount = async (account: any) => {
+    setIsUnlinking(account.accountId);
+    try {
+      const response = await (auth.near as any).setPrimaryAccount({
+        accountId: account.accountId,
+        network: account.network,
+      });
+      if (response.data?.success) {
+        toast.success("Active NEAR account updated");
+        invalidateAccounts();
+      } else {
+        toast.error("Failed to update active NEAR account");
+      }
+    } catch (error) {
+      console.error("Failed to update active NEAR account:", error);
+      toast.error("Failed to update active NEAR account");
     } finally {
       setIsUnlinking(null);
     }
@@ -619,10 +655,10 @@ function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; u
     }
   };
 
-  const primaryAccount = accounts.find((acc) => acc.providerId === "siwn") || accounts[0];
+  const primaryAccount = accounts.find((acc) => acc.isActive || acc.isPrimary) || accounts[0];
   const secondaryAccounts = accounts.filter((acc) => acc !== primaryAccount);
   const isProviderLinked = (providerId: string) =>
-    accounts.some((a) => a.providerId === providerId);
+    accounts.some((a) => getAccountProviderId(a) === providerId);
   const canUnlinkAccount = (account: any) => account !== primaryAccount && accounts.length > 1;
 
   return (
@@ -668,11 +704,11 @@ function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; u
               <div className="flex items-center justify-between p-3 border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)] bg-muted/30">
                 <div className="flex items-center gap-3">
                   <span className="text-lg">
-                    {getProviderConfig(primaryAccount.providerId).icon}
+                    {getProviderConfig(getAccountProviderId(primaryAccount)).icon}
                   </span>
                   <div>
                     <span className="font-medium">
-                      {getProviderConfig(primaryAccount.providerId).name}
+                      {getProviderConfig(getAccountProviderId(primaryAccount)).name}
                     </span>
                     <span className="text-sm text-muted-foreground ml-2">
                       {primaryAccount.accountId}
@@ -693,34 +729,48 @@ function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: any[]; u
                   className="flex items-center justify-between p-3 border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)]"
                 >
                   <div className="flex items-center gap-3">
-                    <span className="text-lg">{getProviderConfig(account.providerId).icon}</span>
+                    <span className="text-lg">
+                      {getProviderConfig(getAccountProviderId(account)).icon}
+                    </span>
                     <div>
                       <span className="font-medium">
-                        {getProviderConfig(account.providerId).name}
+                        {getProviderConfig(getAccountProviderId(account)).name}
                       </span>
                       <span className="text-sm text-muted-foreground ml-2">
                         {account.accountId}
                       </span>
                     </div>
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() =>
-                      account.providerId === "siwn"
-                        ? handleUnlinkNearAccount(account)
-                        : handleUnlinkAccount(account.providerId)
-                    }
-                    disabled={
-                      isUnlinking === (account.providerId || account.accountId) ||
-                      !canUnlinkAccount(account)
-                    }
-                    className="text-destructive hover:text-destructive"
-                  >
-                    {isUnlinking === (account.providerId || account.accountId)
-                      ? "Unlinking..."
-                      : "Unlink"}
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    {getAccountProviderId(account) === "siwn" && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleSetPrimaryNearAccount(account)}
+                        disabled={isUnlinking === (account.providerId || account.accountId)}
+                      >
+                        Set active
+                      </Button>
+                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() =>
+                        getAccountProviderId(account) === "siwn"
+                          ? handleUnlinkNearAccount(account)
+                          : handleUnlinkAccount(account.providerId)
+                      }
+                      disabled={
+                        isUnlinking === (account.providerId || account.accountId) ||
+                        !canUnlinkAccount(account)
+                      }
+                      className="text-destructive hover:text-destructive"
+                    >
+                      {isUnlinking === (account.providerId || account.accountId)
+                        ? "Unlinking..."
+                        : "Unlink"}
+                    </Button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/examples/browser-2-server/apps/web/src/lib/auth-hooks.ts
+++ b/examples/browser-2-server/apps/web/src/lib/auth-hooks.ts
@@ -7,7 +7,7 @@ export function useNearAccounts(session: any) {
     queryKey: ["near-accounts"],
     queryFn: async () => {
       const res = await authClient.near.listAccounts();
-      const accounts = res?.data;
+      const accounts = res?.data?.accounts;
       return Array.isArray(accounts) ? accounts : [];
     },
     enabled: !!session,

--- a/examples/browser-2-server/apps/web/src/lib/auth-utils.ts
+++ b/examples/browser-2-server/apps/web/src/lib/auth-utils.ts
@@ -1,12 +1,16 @@
 /**
  * Extract NEAR accountId from linked accounts
  */
+function getProviderId(account: any): string | null {
+  return typeof account?.providerId === "string" && account.providerId.length > 0 ? account.providerId : null;
+}
+
 export function getNearAccountId(linkedAccounts: any[]): string | null {
   if (!Array.isArray(linkedAccounts)) {
     return null;
   }
-  const nearAccount = linkedAccounts.find(account => account.providerId === 'siwn' || account.providerId === undefined);
-  return (nearAccount?.accountId)?.split(":")[0] || nearAccount?.providerId || null;
+  const nearAccount = linkedAccounts.find(account => getProviderId(account) === "siwn");
+  return nearAccount?.accountId?.split(":")[0] || null;
 }
 
 /**
@@ -16,7 +20,7 @@ export function getLinkedProviders(linkedAccounts: any[]): string[] {
   if (!Array.isArray(linkedAccounts)) {
     return [];
   }
-  return linkedAccounts.map(account => account.providerId ?? 'siwn');
+  return linkedAccounts.map(account => getProviderId(account) ?? "unknown");
 }
 
 /**

--- a/examples/browser-2-server/apps/web/src/lib/auth-utils.ts
+++ b/examples/browser-2-server/apps/web/src/lib/auth-utils.ts
@@ -5,7 +5,7 @@ export function getNearAccountId(linkedAccounts: any[]): string | null {
   if (!Array.isArray(linkedAccounts)) {
     return null;
   }
-  const nearAccount = linkedAccounts.find(account => account.providerId === 'siwn');
+  const nearAccount = linkedAccounts.find(account => account.providerId === 'siwn' || account.providerId === undefined);
   return (nearAccount?.accountId)?.split(":")[0] || nearAccount?.providerId || null;
 }
 
@@ -16,7 +16,7 @@ export function getLinkedProviders(linkedAccounts: any[]): string[] {
   if (!Array.isArray(linkedAccounts)) {
     return [];
   }
-  return linkedAccounts.map(account => account.providerId);
+  return linkedAccounts.map(account => account.providerId ?? 'siwn');
 }
 
 /**

--- a/examples/browser-2-server/apps/web/src/routes/_layout/dashboard.tsx
+++ b/examples/browser-2-server/apps/web/src/routes/_layout/dashboard.tsx
@@ -1,7 +1,7 @@
 import { authClient } from "@/lib/auth-client";
 import { getNearAccountId, getLinkedProviders } from "@/lib/auth-utils";
 import { orpc } from "@/utils/orpc";
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardAction } from "@/components/ui/card";
 import { User, ExternalLink, Unlink, ShieldCheck, Clock, Key, Link2, Focus, UserMinus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -74,6 +74,10 @@ function getProviderName(providerId: string) {
   }
 }
 
+function getAccountProviderId(account: any): string {
+  return account?.providerId ?? (account?.accountId ? "siwn" : "unknown");
+}
+
 export const Route = createFileRoute("/_layout/dashboard")({
   beforeLoad: async ({ location }) => {
     const { data: session } = await authClient.getSession();
@@ -96,11 +100,12 @@ export const Route = createFileRoute("/_layout/dashboard")({
     ]);
 
     const session = sessionRes.data;
-    const linkedAccounts = Array.isArray(accountsRes?.data) ? accountsRes.data : [];
+    const linkedAccounts = accountsRes?.data?.accounts ?? [];
+    const activeNearAccount = accountsRes?.data?.activeAccount ?? null;
     const sessionNearAccountId = (session?.user as any)?.nearAccount?.accountId;
-    const nearAccountId = sessionNearAccountId
+    const nearAccountId = activeNearAccount?.accountId ?? (sessionNearAccountId
       ? sessionNearAccountId.split(":")[0]
-      : getNearAccountId(linkedAccounts);
+      : getNearAccountId(linkedAccounts));
     const linkedProviders = getLinkedProviders(linkedAccounts);
 
     return {
@@ -400,6 +405,7 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
   nearAccountId: string | null;
 }) {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const [isLinkingGoogle, setIsLinkingGoogle] = useState(false);
   const [isLinkingGitHub, setIsLinkingGitHub] = useState(false);
   const [isProcessingNear, setIsProcessingNear] = useState(false);
@@ -408,8 +414,10 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
   const walletAccountId = authClient.near.getAccountId();
   const accounts = linkedAccounts;
 
-  const invalidateAccounts = () =>
-    queryClient.invalidateQueries({ queryKey: ["near-accounts"] });
+  const invalidateAccounts = () => {
+    void queryClient.invalidateQueries({ queryKey: ["near-accounts"] });
+    void router.invalidate();
+  };
 
   const handleLinkSocial = async (providerId: "google" | "github") => {
     if (providerId === "google") setIsLinkingGoogle(true);
@@ -453,10 +461,10 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
   const handleUnlinkNearAccount = async (account: any) => {
     setIsUnlinking(account.accountId);
     try {
-      const [accountId, network] = account.accountId.split(":");
+      const [accountId, fallbackNetwork] = account.accountId.split(":");
       const response = await authClient.near.unlink({
         accountId,
-        network: (network as "mainnet" | "testnet") || "mainnet",
+        network: (account.network as "mainnet" | "testnet") || (fallbackNetwork as "mainnet" | "testnet") || "mainnet",
       });
       if (response.data?.success) {
         toast.success("NEAR account unlinked successfully");
@@ -467,6 +475,27 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
     } catch (error) {
       console.error("Failed to unlink NEAR account:", error);
       toast.error("Failed to unlink NEAR account");
+    } finally {
+      setIsUnlinking(null);
+    }
+  };
+
+  const handleSetPrimaryNearAccount = async (account: any) => {
+    setIsUnlinking(account.accountId);
+    try {
+      const response = await authClient.near.setPrimaryAccount({
+        accountId: account.accountId,
+        network: account.network,
+      });
+      if (response.data?.success) {
+        toast.success("Active NEAR account updated");
+        invalidateAccounts();
+      } else {
+        toast.error("Failed to update active NEAR account");
+      }
+    } catch (error) {
+      console.error("Failed to update active NEAR account:", error);
+      toast.error("Failed to update active NEAR account");
     } finally {
       setIsUnlinking(null);
     }
@@ -486,9 +515,9 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
     }
   };
 
-  const primaryAccount = accounts.find((acc) => acc.providerId === "siwn") || accounts[0];
+  const primaryAccount = accounts.find((acc) => acc.isActive || acc.isPrimary) || accounts[0];
   const secondaryAccounts = accounts.filter((acc) => acc !== primaryAccount);
-  const isProviderLinked = (providerId: string) => accounts.some((a) => a.providerId === providerId);
+  const isProviderLinked = (providerId: string) => accounts.some((a) => getAccountProviderId(a) === providerId);
   const canUnlinkAccount = (account: any) => account !== primaryAccount && accounts.length > 1;
 
   return (
@@ -509,9 +538,9 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
             </h4>
             <div className="flex items-center justify-between p-3 border rounded-lg bg-muted/30">
               <div className="flex items-center gap-3">
-                <span className="text-lg">{getProviderIcon(primaryAccount.providerId)}</span>
+                <span className="text-lg">{getProviderIcon(getAccountProviderId(primaryAccount))}</span>
                 <div>
-                  <span className="font-medium">{getProviderName(primaryAccount.providerId)}</span>
+                  <span className="font-medium">{getProviderName(getAccountProviderId(primaryAccount))}</span>
                   <span className="text-sm text-muted-foreground ml-2">{primaryAccount.accountId}</span>
                 </div>
               </div>
@@ -526,21 +555,33 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
             {secondaryAccounts.map((account) => (
               <div key={account.providerId || account.accountId} className="flex items-center justify-between p-3 border rounded-lg">
                 <div className="flex items-center gap-3">
-                  <span className="text-lg">{getProviderIcon(account.providerId)}</span>
+                  <span className="text-lg">{getProviderIcon(getAccountProviderId(account))}</span>
                   <div>
-                    <span className="font-medium">{getProviderName(account.providerId)}</span>
+                    <span className="font-medium">{getProviderName(getAccountProviderId(account))}</span>
                     <span className="text-sm text-muted-foreground ml-2">{account.accountId}</span>
                   </div>
                 </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => account.providerId === "siwn" ? handleUnlinkNearAccount(account) : handleUnlinkAccount(account.providerId)}
-                  disabled={isUnlinking === (account.providerId || account.accountId) || !canUnlinkAccount(account)}
-                  className="text-destructive hover:text-destructive"
-                >
-                  {isUnlinking === (account.providerId || account.accountId) ? "Unlinking..." : "Unlink"}
-                </Button>
+                <div className="flex items-center gap-2">
+                  {getAccountProviderId(account) === "siwn" && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleSetPrimaryNearAccount(account)}
+                      disabled={isUnlinking === (account.providerId || account.accountId)}
+                    >
+                      Set active
+                    </Button>
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => getAccountProviderId(account) === "siwn" ? handleUnlinkNearAccount(account) : handleUnlinkAccount(account.providerId)}
+                    disabled={isUnlinking === (account.providerId || account.accountId) || !canUnlinkAccount(account)}
+                    className="text-destructive hover:text-destructive"
+                  >
+                    {isUnlinking === (account.providerId || account.accountId) ? "Unlinking..." : "Unlink"}
+                  </Button>
+                </div>
               </div>
             ))}
           </div>

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import { hex } from "@scure/base";
 import type { BetterAuthClientPlugin, BetterAuthClientOptions, BetterFetch, BetterFetchOption, BetterFetchResponse, ClientStore } from "better-auth/client";
 import { atom } from "nanostores";
 import type { siwn } from "./index.js";
-import { type AccountId, type NonceRequestT, type NonceResponseT, type ProfileResponseT, type VerifyRequestT, type VerifyResponseT, type RelayResponseT, type RelayStatusResponseT, type NearAccount, type ViewContractRequestT, type ViewContractResponseT, type RelayerInfo, type RelayHistoryResponseT } from "./types.js";
+import { type AccountId, type NonceRequestT, type NonceResponseT, type ProfileResponseT, type VerifyRequestT, type VerifyResponseT, type RelayResponseT, type RelayStatusResponseT, type NearAccount, type ListAccountsResponseT, type SetPrimaryAccountRequestT, type SetPrimaryAccountResponseT, type ViewContractRequestT, type ViewContractResponseT, type RelayerInfo, type RelayHistoryResponseT } from "./types.js";
 
 export interface AuthCallbacks {
 	onSuccess?: () => void;
@@ -38,7 +38,8 @@ export interface SIWNClientActions {
 		disconnect: () => Promise<void>;
 		link: (callbacks?: AuthCallbacks) => Promise<void>;
 		unlink: (params: { accountId: string; network?: "mainnet" | "testnet" }) => Promise<BetterFetchResponse<{ success: boolean; message: string }>>;
-		listAccounts: () => Promise<BetterFetchResponse<{ accounts: NearAccount[] }>>;
+		listAccounts: () => Promise<BetterFetchResponse<ListAccountsResponseT>>;
+		setPrimaryAccount: (params: SetPrimaryAccountRequestT) => Promise<BetterFetchResponse<SetPrimaryAccountResponseT>>;
 		buildSignedDelegateAction: (receiverId: string, buildActions: (builder: TransactionBuilder, receiverId: string) => TransactionBuilder) => Promise<string>;
 		relayTransaction: (params: { payload: string }) => Promise<BetterFetchResponse<RelayResponseT>>;
 		getRelayStatus: (txHash: string) => Promise<BetterFetchResponse<RelayStatusResponseT>>;
@@ -140,10 +141,10 @@ export const siwnClient = (config: SIWNClientConfig): SIWNClientPlugin => {
 		}
 
 		try {
-			const res = await $fetch<{ accounts: NearAccount[] }>("/near/list-accounts", { method: "GET" });
+			const res = await $fetch<ListAccountsResponseT>("/near/list-accounts", { method: "GET" });
 			const accounts = res.data?.accounts;
 			if (accounts?.length) {
-				const primary = accounts.find((a: NearAccount) => a.isPrimary) || accounts[0];
+				const primary = res.data?.activeAccount || accounts.find((a: NearAccount) => a.isPrimary) || accounts[0];
 				if (primary) {
 					nearState.set({
 						accountId: primary.accountId,
@@ -400,8 +401,25 @@ export const siwnClient = (config: SIWNClientConfig): SIWNClientPlugin => {
 							...fetchOptions
 						});
 					},
-					listAccounts: async (): Promise<BetterFetchResponse<{ accounts: NearAccount[] }>> => {
+					listAccounts: async (): Promise<BetterFetchResponse<ListAccountsResponseT>> => {
 						return await $fetch("/near/list-accounts", { method: "GET" });
+					},
+					setPrimaryAccount: async (
+						params: SetPrimaryAccountRequestT
+					): Promise<BetterFetchResponse<SetPrimaryAccountResponseT>> => {
+						const response = await $fetch<SetPrimaryAccountResponseT>("/near/set-primary-account", {
+							method: "POST",
+							body: params,
+						});
+						const activeAccount = response.data?.activeAccount;
+						if (activeAccount) {
+							nearState.set({
+								accountId: activeAccount.accountId,
+								publicKey: activeAccount.publicKey ?? null,
+								networkId: activeAccount.network,
+							});
+						}
+						return response;
 					},
 					buildSignedDelegateAction: async (
 						receiverId: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { defaultGetProfile, getImageUrl, getNetworkFromAccountId } from "./profi
 import { schema } from "./schema.js";
 import type {
 	AccountId,
+	ListAccountsResponseT,
+	ListedNearAccount,
 	NearAccount,
 	Profile,
 	RelayerInfo,
@@ -25,6 +27,7 @@ import {
 	RelayRequest,
 	RelayResponse,
 	RelayStatusResponse,
+	SetPrimaryAccountRequest,
 	ViewContractRequest,
 	ViewContractResponse,
 } from "./types.js";
@@ -49,6 +52,44 @@ function deriveEmail(accountId: string): string | null {
 		return `${localPart}@near.email`;
 	}
 	return null;
+}
+
+function nearAccountKey(account: Pick<NearAccount, "accountId" | "network">): string {
+	return `${account.accountId}:${account.network}`;
+}
+
+function getCreatedAtTime(account: NearAccount): number {
+	return account.createdAt instanceof Date
+		? account.createdAt.getTime()
+		: new Date(account.createdAt).getTime();
+}
+
+function buildListAccountsResponse(nearAccounts: NearAccount[]): ListAccountsResponseT {
+	const activeAccount = nearAccounts.find((account) => account.isPrimary) ?? nearAccounts[0] ?? null;
+	const activeKey = activeAccount ? nearAccountKey(activeAccount) : null;
+	const accounts: ListedNearAccount[] = nearAccounts
+		.map((account) => {
+			const isActive = activeKey === nearAccountKey(account);
+			return {
+				...account,
+				providerId: "siwn" as const,
+				isActive,
+				isAvailable: !isActive,
+			};
+		})
+		.sort((a, b) => {
+			if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
+			return getCreatedAtTime(a) - getCreatedAtTime(b);
+		});
+	const listedActiveAccount = accounts.find((account) => account.isActive) ?? null;
+
+	return {
+		accounts,
+		activeAccount: listedActiveAccount ? { ...listedActiveAccount } : null,
+		availableAccounts: accounts
+			.filter((account) => account.isAvailable)
+			.map((account) => ({ ...account })),
+	};
 }
 
 export interface RelayerConfig {
@@ -530,7 +571,60 @@ export const siwn = (options: SIWNPluginOptions): BetterAuthPlugin => {
 						where: [{ field: "userId", operator: "eq", value: session.user.id }],
 					});
 
-					return ctx.json({ accounts: nearAccounts });
+					return ctx.json(buildListAccountsResponse(nearAccounts));
+				},
+			),
+			setPrimaryNearAccount: createAuthEndpoint(
+				"/near/set-primary-account",
+				{
+					method: "POST",
+					body: SetPrimaryAccountRequest,
+					use: [sessionMiddleware],
+				},
+				async (ctx) => {
+					const { accountId, network: providedNetwork } = ctx.body;
+					const session = ctx.context.session;
+					const network = providedNetwork || getNetworkFromAccountId(accountId);
+
+					const targetAccount: NearAccount | null = await ctx.context.adapter.findOne({
+						model: "nearAccount",
+						where: [
+							{ field: "userId", operator: "eq", value: session.user.id },
+							{ field: "accountId", operator: "eq", value: accountId },
+							{ field: "network", operator: "eq", value: network },
+						],
+					});
+
+					if (!targetAccount) {
+						throw new APIError("NOT_FOUND", {
+							message: "NEAR account not found or not linked to your user",
+							status: 404,
+						});
+					}
+
+					const nearAccounts: NearAccount[] = await ctx.context.adapter.findMany({
+						model: "nearAccount",
+						where: [{ field: "userId", operator: "eq", value: session.user.id }],
+					});
+
+					await Promise.all(nearAccounts.map((account) => ctx.context.adapter.update({
+						model: "nearAccount",
+						where: [{ field: "id", operator: "eq", value: account.id }],
+						update: { isPrimary: nearAccountKey(account) === nearAccountKey(targetAccount) },
+					})));
+
+					const updatedNearAccounts: NearAccount[] = await ctx.context.adapter.findMany({
+						model: "nearAccount",
+						where: [{ field: "userId", operator: "eq", value: session.user.id }],
+					});
+
+					return ctx.json({
+						success: true,
+						accountId,
+						network,
+						message: "Primary NEAR account updated",
+						...buildListAccountsResponse(updatedNearAccounts),
+					});
 				},
 			),
 			getSiwnNonce: createAuthEndpoint(

--- a/src/near.test.ts
+++ b/src/near.test.ts
@@ -184,6 +184,20 @@ async function setup(overrides?: {
 	);
 }
 
+async function verifyWithCookie(customFetchImpl: any): Promise<string> {
+	const res = await customFetchImpl("http://localhost/api/auth/near/verify", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(makeVerifyBody()),
+	});
+	expect(res.status).toBe(200);
+	const cookie = res.headers.get("set-cookie") || "";
+	expect(cookie).not.toBe("");
+	return cookie;
+}
+
 describe("siwn plugin", () => {
 	describe("nonce endpoint", () => {
 		it("should generate a nonce for a valid mainnet account ID", async () => {
@@ -362,16 +376,90 @@ describe("siwn plugin", () => {
 
 	describe("list accounts endpoint", () => {
 		it("should list NEAR accounts for authenticated user", async () => {
-			const { client } = await setup();
-			await client.near.verify(makeVerifyBody());
+			const { customFetchImpl } = await setup();
+			const cookie = await verifyWithCookie(customFetchImpl);
 
-			const { data, error } = await client.near.listAccounts();
-			if (error) {
-				expect(error).toBeDefined();
-			} else {
-				expect(data?.accounts).toBeDefined();
-				expect(Array.isArray(data?.accounts)).toBe(true);
-			}
+			const res = await customFetchImpl("http://localhost/api/auth/near/list-accounts", {
+				method: "GET",
+				headers: { cookie },
+			});
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data?.accounts).toHaveLength(1);
+			expect(data?.activeAccount?.accountId).toBe(MOCK_ACCOUNT_ID);
+			expect(data?.availableAccounts).toEqual([]);
+			expect(data?.accounts[0]?.providerId).toBe("siwn");
+			expect(data?.accounts[0]?.isActive).toBe(true);
+			expect(data?.accounts[0]?.isAvailable).toBe(false);
+		});
+
+		it("should mark primary account active and non-primary accounts available", async () => {
+			const { customFetchImpl, db } = await setup();
+			const cookie = await verifyWithCookie(customFetchImpl);
+
+			const [primaryAccount] = await db.findMany({ model: "nearAccount" });
+			await db.create({
+				model: "nearAccount",
+				data: {
+					userId: primaryAccount.userId,
+					accountId: "secondary.near",
+					network: "mainnet",
+					publicKey: MOCK_PUBLIC_KEY,
+					isPrimary: false,
+					createdAt: new Date(),
+				},
+			});
+
+			const res = await customFetchImpl("http://localhost/api/auth/near/list-accounts", {
+				method: "GET",
+				headers: { cookie },
+			});
+			expect(res.status).toBe(200);
+			const data = await res.json();
+			expect(data?.activeAccount?.accountId).toBe(MOCK_ACCOUNT_ID);
+			expect(data?.availableAccounts).toHaveLength(1);
+			expect(data?.availableAccounts[0]?.accountId).toBe("secondary.near");
+			expect(data?.accounts.map((account: any) => account.accountId)).toEqual([
+				MOCK_ACCOUNT_ID,
+				"secondary.near",
+			]);
+		});
+
+		it("should select a primary NEAR account", async () => {
+			const { customFetchImpl, db } = await setup();
+			const cookie = await verifyWithCookie(customFetchImpl);
+
+			const [primaryAccount] = await db.findMany({ model: "nearAccount" });
+			await db.create({
+				model: "nearAccount",
+				data: {
+					userId: primaryAccount.userId,
+					accountId: "secondary.near",
+					network: "mainnet",
+					publicKey: MOCK_PUBLIC_KEY,
+					isPrimary: false,
+					createdAt: new Date(),
+				},
+			});
+
+			const res = await customFetchImpl("http://localhost/api/auth/near/set-primary-account", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					cookie,
+				},
+				body: JSON.stringify({
+					accountId: "secondary.near",
+				}),
+			});
+			expect(res.status).toBe(200);
+			const data = await res.json();
+
+			expect(data?.success).toBe(true);
+			expect(data?.activeAccount?.accountId).toBe("secondary.near");
+			expect(data?.availableAccounts.map((account: any) => account.accountId)).toEqual([
+				MOCK_ACCOUNT_ID,
+			]);
 		});
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,25 @@ export interface NearAccount {
 	createdAt: Date;
 }
 
+export interface ListedNearAccount extends NearAccount {
+	providerId: "siwn";
+	isActive: boolean;
+	isAvailable: boolean;
+}
+
+export interface ListAccountsResponseT {
+	accounts: ListedNearAccount[];
+	activeAccount: ListedNearAccount | null;
+	availableAccounts: ListedNearAccount[];
+}
+
+export interface SetPrimaryAccountResponseT extends ListAccountsResponseT {
+	success: boolean;
+	accountId: string;
+	network: "mainnet" | "testnet";
+	message: string;
+}
+
 export const socialImageSchema = z.object({
 	url: z.string().optional(),
 	ipfs_cid: z.string().optional(),
@@ -43,6 +62,11 @@ export const LinkAccountRequest = z.object({
 	recipient: z.string(),
 	nonce: z.string(),
 	accountId: AccountIdSchema,
+});
+
+export const SetPrimaryAccountRequest = z.object({
+	accountId: AccountIdSchema,
+	network: z.enum(["mainnet", "testnet"]).optional(),
 });
 
 export const NonceRequest = z.object({
@@ -103,6 +127,7 @@ export type ProfileRequestT = z.infer<typeof ProfileRequest>;
 
 export type NonceRequestT = z.infer<typeof NonceRequest>;
 export type NonceResponseT = z.infer<typeof NonceResponse>;
+export type SetPrimaryAccountRequestT = z.infer<typeof SetPrimaryAccountRequest>;
 export type VerifyRequestT = z.infer<typeof VerifyRequest>;
 export type VerifyResponseT = z.infer<typeof VerifyResponse>;
 export type ProfileResponseT = z.infer<typeof ProfileResponse>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,10 +2,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    include: ["src/**/*.test.ts"],
     exclude: [
       "**/node_modules/**",
-      "**/examples/plugin/**",
       "**/dist/**",
+      "**/examples/**",
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Fixes NEAR account listing so responses include an explicit active account plus available selectable accounts.
- Adds client support for switching the active NEAR account via `near.setPrimaryAccount()` and keeps client state in sync.
- Updates the browser-to-server example to display active/secondary accounts correctly and avoid treating missing provider IDs as SIWN accounts.
- Adds tests and release notes for the account listing behavior.

## Linked Issue
Closes #33

## Validation
- `pnpm typecheck`
- `coderabbit review --base main --plain --no-color` returned no findings

Note: `pnpm --dir examples/browser-2-server/apps/web check-types` is currently blocked by the example server declaration output not being present at `apps/server/dist/src/routers/index.d.ts`.


## Preview

<img width="994" height="368" alt="image" src="https://github.com/user-attachments/assets/ef60c43d-e861-4ded-9254-4e96fe1cfd8e" />