### PR TITLE
Fix passkey support in auth example

### DIFF
--- a/examples/auth.everything.dev/.changeset/passkey-support.md
+++ b/examples/auth.everything.dev/.changeset/passkey-support.md
@@ -1,0 +1,5 @@
+---
+"@everything-dev/auth-plugin": minor
+---
+
+Configure Better Auth passkeys with explicit WebAuthn relying party settings and enable first-class passkey login and credential management in the example app.

--- a/examples/auth.everything.dev/.env.example
+++ b/examples/auth.everything.dev/.env.example
@@ -35,3 +35,8 @@ ZE_USER_EMAIL=
 # GitHub OAuth
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+
+# Passkeys (optional; defaults derive from DOMAIN/http://localhost:3000)
+PASSKEY_RP_ID=
+PASSKEY_RP_NAME=
+PASSKEY_ORIGIN=

--- a/examples/auth.everything.dev/bos.config.json
+++ b/examples/auth.everything.dev/bos.config.json
@@ -122,6 +122,11 @@
       "development": "local:plugins/auth",
       "production": "https://elliot-braem-3605-everything-dev-auth-plugin-bett-f19f96ec0-ze.zephyrcloud.app",
       "integrity": "sha384-0+6PBccgYZwLDVxJJ3LDeA0EledPagot9TwxGvq59+qoJaBVc8qHJcxPTJNiHI6X",
+      "variables": {
+        "account": "auth.everything.near",
+        "domain": "everything.dev",
+        "passkeyRpName": "Everything Dev"
+      },
       "secrets": [
         "AUTH_DATABASE_URL",
         "BETTER_AUTH_SECRET",

--- a/examples/auth.everything.dev/plugins/auth/README.md
+++ b/examples/auth.everything.dev/plugins/auth/README.md
@@ -39,6 +39,9 @@ It runs inside the **everything-plugin** framework (oRPC + Effect) and is design
 | `domain` | `string` | — | Optional. Base URL of the auth server |
 | `githubClientId` | `string` | — | Optional. GitHub OAuth client ID |
 | `githubClientSecret` | `string` | — | Optional. GitHub OAuth client secret |
+| `passkeyRpId` | `string` | Derived from `domain` | Optional. WebAuthn relying party ID, usually the registrable domain such as `everything.dev` or `localhost` |
+| `passkeyRpName` | `string` | `Everything Dev` | Optional. Human-readable passkey relying party name shown by authenticators |
+| `passkeyOrigin` | `string` | Derived from `domain` | Optional. Browser origin where passkeys are created and used, without a trailing path |
 
 ### Plugin Secrets
 
@@ -63,6 +66,9 @@ The plugin itself does **not** read `process.env`. The host passes all configura
 | `DOMAIN` | Base URL of the auth server (dev fallback) |
 | `GITHUB_CLIENT_ID` | GitHub OAuth client ID (dev fallback) |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth client secret (dev fallback) |
+| `PASSKEY_RP_ID` | WebAuthn relying party ID override (dev fallback) |
+| `PASSKEY_RP_NAME` | WebAuthn relying party display name override (dev fallback) |
+| `PASSKEY_ORIGIN` | WebAuthn origin override (dev fallback) |
 | `AUTH_DATABASE_URL` | Database URL (dev fallback) |
 | `BETTER_AUTH_SECRET` | Session signing secret (dev fallback) |
 
@@ -96,6 +102,8 @@ AUTH_DATABASE_URL=postgres://user:pass@host:5432/dbname
 ### Passkeys (FIDO2/WebAuthn)
 - Uses `@better-auth/passkey`
 - `@simplewebauthn/server` required at dev time
+- Configures `rpID`, `rpName`, and `origin` explicitly from plugin variables so passkeys work on localhost, staging, and production domains
+- Users can sign in with passkeys and manage registered credentials from settings
 
 ### Anonymous Accounts
 - Instant sign-up without credentials

--- a/examples/auth.everything.dev/plugins/auth/plugin.dev.ts
+++ b/examples/auth.everything.dev/plugins/auth/plugin.dev.ts
@@ -12,6 +12,9 @@ export default {
       domain: process.env.DOMAIN || "http://localhost:3000",
       githubClientId: process.env.GITHUB_CLIENT_ID,
       githubClientSecret: process.env.GITHUB_CLIENT_SECRET,
+      passkeyRpId: process.env.PASSKEY_RP_ID,
+      passkeyRpName: process.env.PASSKEY_RP_NAME,
+      passkeyOrigin: process.env.PASSKEY_ORIGIN,
     },
     secrets: {
       AUTH_DATABASE_URL: process.env.AUTH_DATABASE_URL || "pglite:.bos/auth/:memory:",

--- a/examples/auth.everything.dev/plugins/auth/src/auth-export.ts
+++ b/examples/auth.everything.dev/plugins/auth/src/auth-export.ts
@@ -29,6 +29,9 @@ export interface AuthConfig {
   trustedOrigins?: string[];
   githubClientId?: string;
   githubClientSecret?: string;
+  passkeyRpId?: string;
+  passkeyRpName?: string;
+  passkeyOrigin?: string;
   fastnearApiKey?: string;
   nearRpcUrl?: string;
   isProduction?: boolean;

--- a/examples/auth.everything.dev/plugins/auth/src/auth-instance.test.ts
+++ b/examples/auth.everything.dev/plugins/auth/src/auth-instance.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { resolvePasskeyRelyingPartyOptions } from "./auth-instance";
+
+describe("resolvePasskeyRelyingPartyOptions", () => {
+  it("derives localhost relying party options from baseUrl", () => {
+    expect(
+      resolvePasskeyRelyingPartyOptions({
+        baseUrl: "http://localhost:3000",
+      }),
+    ).toEqual({
+      rpID: "localhost",
+      rpName: "Everything Dev",
+      origin: "http://localhost:3000",
+    });
+  });
+
+  it("drops path segments when deriving production origin", () => {
+    expect(
+      resolvePasskeyRelyingPartyOptions({
+        baseUrl: "https://everything.dev/auth",
+      }),
+    ).toEqual({
+      rpID: "everything.dev",
+      rpName: "Everything Dev",
+      origin: "https://everything.dev",
+    });
+  });
+
+  it("normalizes explicit passkey overrides", () => {
+    expect(
+      resolvePasskeyRelyingPartyOptions({
+        baseUrl: "http://localhost:3000",
+        passkeyOrigin: "https://auth.example.com/passkey",
+        passkeyRpId: "https://example.com:443",
+        passkeyRpName: "Example Auth",
+      }),
+    ).toEqual({
+      rpID: "example.com",
+      rpName: "Example Auth",
+      origin: "https://auth.example.com",
+    });
+  });
+
+  it("treats localhost origins without a protocol as http", () => {
+    expect(
+      resolvePasskeyRelyingPartyOptions({
+        baseUrl: "http://localhost:3000",
+        passkeyOrigin: "localhost:3000",
+      }),
+    ).toMatchObject({
+      rpID: "localhost",
+      origin: "http://localhost:3000",
+    });
+  });
+
+  it("throws a descriptive error for invalid passkey origin", () => {
+    expect(() =>
+      resolvePasskeyRelyingPartyOptions({
+        baseUrl: "http://localhost:3000",
+        passkeyOrigin: "https://",
+      }),
+    ).toThrow('Invalid passkey origin value: "https://"');
+  });
+
+  it("throws a descriptive error for invalid passkey RP ID", () => {
+    expect(() =>
+      resolvePasskeyRelyingPartyOptions({
+        baseUrl: "http://localhost:3000",
+        passkeyRpId: "https://",
+      }),
+    ).toThrow('Invalid passkey RP ID value: "https://"');
+  });
+});

--- a/examples/auth.everything.dev/plugins/auth/src/auth-instance.ts
+++ b/examples/auth.everything.dev/plugins/auth/src/auth-instance.ts
@@ -8,6 +8,51 @@ import type { AuthConfig } from "./auth-export";
 import type { AuthDatabase } from "./db/driver";
 import * as schema from "./db/schema";
 
+export interface PasskeyRelyingPartyOptions {
+  rpID: string;
+  rpName: string;
+  origin: string;
+}
+
+function normalizeOrigin(value: string): string {
+  try {
+    if (/^https?:\/\//i.test(value)) {
+      return new URL(value).origin;
+    }
+    const hostname = new URL(`https://${value}`).hostname;
+    const protocol = hostname === "localhost" || hostname === "127.0.0.1" ? "http" : "https";
+    return new URL(`${protocol}://${value}`).origin;
+  } catch {
+    throw new Error(`Invalid passkey origin value: "${value}". Must be a valid URL or hostname.`);
+  }
+}
+
+function normalizeRpId(value: string): string {
+  try {
+    const hostname = /^https?:\/\//i.test(value)
+      ? new URL(value).hostname
+      : new URL(`https://${value}`).hostname;
+    if (!hostname) {
+      throw new TypeError("Missing hostname");
+    }
+    return hostname;
+  } catch {
+    throw new Error(`Invalid passkey RP ID value: "${value}". Must be a valid domain or URL.`);
+  }
+}
+
+export function resolvePasskeyRelyingPartyOptions(
+  config: Pick<AuthConfig, "baseUrl" | "passkeyOrigin" | "passkeyRpId" | "passkeyRpName">,
+): PasskeyRelyingPartyOptions {
+  const origin = normalizeOrigin(config.passkeyOrigin?.trim() || config.baseUrl);
+  const rpID = config.passkeyRpId?.trim()
+    ? normalizeRpId(config.passkeyRpId.trim())
+    : new URL(origin).hostname;
+  const rpName = config.passkeyRpName?.trim() || "Everything Dev";
+
+  return { rpID, rpName, origin };
+}
+
 async function sendEmail({ to, subject, text }: { to: string; subject: string; text: string }) {
   console.log(`\n📧 [Email Preview] ============================================`);
   console.log(`To: ${to}`);
@@ -70,6 +115,8 @@ async function createPersonalOrganization(
 }
 
 export function createAuthInstance(config: AuthConfig, db: AuthDatabase) {
+  const passkeyOptions = resolvePasskeyRelyingPartyOptions(config);
+
   return betterAuth({
     database: drizzleAdapter(db, {
       provider: "pg",
@@ -102,7 +149,7 @@ export function createAuthInstance(config: AuthConfig, db: AuthDatabase) {
           getTempName: (phoneNumber) => phoneNumber,
         },
       }),
-      passkey(),
+      passkey(passkeyOptions),
       organization({
         async sendInvitationEmail(data) {
           const inviteLink = `${config.baseUrl}/accept-invitation/${data.id}`;

--- a/examples/auth.everything.dev/plugins/auth/src/index.ts
+++ b/examples/auth.everything.dev/plugins/auth/src/index.ts
@@ -122,6 +122,9 @@ export default createPlugin({
     domain: z.string().optional(),
     githubClientId: z.string().optional(),
     githubClientSecret: z.string().optional(),
+    passkeyRpId: z.string().optional(),
+    passkeyRpName: z.string().optional(),
+    passkeyOrigin: z.string().optional(),
   }),
 
   secrets: z.object({
@@ -151,6 +154,9 @@ export default createPlugin({
         config.variables.domain,
         config.secrets.CORS_ORIGIN,
       );
+      const passkeyOrigin = config.variables.passkeyOrigin
+        ? ensureOrigin(config.variables.passkeyOrigin)
+        : undefined;
 
       const auth = createAuthInstance(
         {
@@ -160,6 +166,9 @@ export default createPlugin({
           trustedOrigins,
           githubClientId: config.variables.githubClientId,
           githubClientSecret: config.variables.githubClientSecret,
+          passkeyRpId: config.variables.passkeyRpId,
+          passkeyRpName: config.variables.passkeyRpName,
+          passkeyOrigin: passkeyOrigin ?? undefined,
         },
         driver.db,
       );

--- a/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/settings.tsx
+++ b/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/settings.tsx
@@ -40,16 +40,18 @@ export const Route = createFileRoute("/_layout/_authenticated/settings")({
 function Settings() {
   const auth = useAuthClient();
   const { data: session } = useQuery<SessionData | null>(sessionQueryOptions(auth));
+  const user = session?.user;
+  const passkeyQueryKey = ["passkeys", user?.id] as const;
   const { data: passkeys = [] } = useQuery({
-    queryKey: ["passkeys"],
+    queryKey: passkeyQueryKey,
     queryFn: async () => {
       const { data } = await auth.passkey.listUserPasskeys();
       return (data || []) as Passkey[];
     },
+    enabled: !!user?.id,
     staleTime: 60 * 1000,
   });
 
-  const user = session?.user;
   const nearAccountId = auth.near.getAccountId();
 
   if (!user) {
@@ -181,18 +183,31 @@ function AuthMethodsTab({
   passkeys,
   nearAccountId,
 }: {
-  user: { email?: string; isAnonymous?: boolean | null };
+  user: { id: string; email?: string; isAnonymous?: boolean | null };
   passkeys: Array<{ id: string; name?: string }>;
   nearAccountId: string | null;
 }) {
   const auth = useAuthClient();
+  const queryClient = useQueryClient();
+  const [passkeyName, setPasskeyName] = useState("");
+  const [passkeyToDelete, setPasskeyToDelete] = useState<{ id: string; name?: string } | null>(
+    null,
+  );
+  const passkeyQueryKey = ["passkeys", user.id] as const;
 
   const addPasskeyMutation = useMutation({
     mutationFn: async () => {
-      const { error } = await auth.passkey.addPasskey();
+      const name = passkeyName.trim();
+      const { error } = name
+        ? await auth.passkey.addPasskey({ name })
+        : await auth.passkey.addPasskey();
       if (error) throw new Error(error.message);
     },
-    onSuccess: () => toast.success("Passkey added"),
+    onSuccess: () => {
+      setPasskeyName("");
+      toast.success("Passkey added");
+      queryClient.invalidateQueries({ queryKey: passkeyQueryKey });
+    },
     onError: (err: Error) => toast.error(err.message),
   });
 
@@ -201,7 +216,11 @@ function AuthMethodsTab({
       const { error } = await auth.passkey.deletePasskey({ id: passkeyId });
       if (error) throw new Error(error.message);
     },
-    onSuccess: () => toast.success("Passkey removed"),
+    onSuccess: () => {
+      setPasskeyToDelete(null);
+      toast.success("Passkey removed");
+      queryClient.invalidateQueries({ queryKey: passkeyQueryKey });
+    },
     onError: (err: Error) => toast.error(err.message),
   });
 
@@ -214,66 +233,90 @@ function AuthMethodsTab({
   });
 
   return (
-    <div className="grid gap-4 lg:grid-cols-3">
-      <MethodCard title="email" status={user.email ? "linked" : "missing"}>
-        <p className="text-sm text-muted-foreground">
-          {user.email ?? "Email login has not been linked for this account yet."}
-        </p>
-      </MethodCard>
+    <>
+      <div className="grid gap-4 lg:grid-cols-3">
+        <MethodCard title="email" status={user.email ? "linked" : "missing"}>
+          <p className="text-sm text-muted-foreground">
+            {user.email ?? "Email login has not been linked for this account yet."}
+          </p>
+        </MethodCard>
 
-      <MethodCard title="near" status={nearAccountId ? "linked" : "missing"}>
-        {nearAccountId ? (
-          <div className="border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)] bg-muted/30 p-3 font-mono text-xs break-all">
-            {nearAccountId}
-          </div>
-        ) : (
-          <Button
-            onClick={() => linkNearMutation.mutate()}
-            disabled={linkNearMutation.isPending}
-            variant="outline"
-            size="sm"
-          >
-            {linkNearMutation.isPending ? "linking..." : "link NEAR wallet"}
-          </Button>
-        )}
-      </MethodCard>
-
-      <MethodCard
-        title="passkeys"
-        status={passkeys.length > 0 ? `${passkeys.length} linked` : "missing"}
-      >
-        <div className="space-y-2">
-          {passkeys.length > 0 ? (
-            passkeys.map((passkey) => (
-              <div
-                key={passkey.id}
-                className="border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)] bg-muted/30 p-3 flex items-center justify-between gap-3"
-              >
-                <span className="text-sm truncate">{passkey.name || "Passkey"}</span>
-                <Button
-                  onClick={() => removePasskeyMutation.mutate(passkey.id)}
-                  disabled={removePasskeyMutation.isPending}
-                  variant="outline"
-                  size="sm"
-                >
-                  remove
-                </Button>
-              </div>
-            ))
+        <MethodCard title="near" status={nearAccountId ? "linked" : "missing"}>
+          {nearAccountId ? (
+            <div className="border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)] bg-muted/30 p-3 font-mono text-xs break-all">
+              {nearAccountId}
+            </div>
           ) : (
-            <p className="text-sm text-muted-foreground">No passkeys registered yet.</p>
+            <Button
+              onClick={() => linkNearMutation.mutate()}
+              disabled={linkNearMutation.isPending}
+              variant="outline"
+              size="sm"
+            >
+              {linkNearMutation.isPending ? "linking..." : "link NEAR wallet"}
+            </Button>
           )}
-          <Button
-            onClick={() => addPasskeyMutation.mutate()}
-            disabled={addPasskeyMutation.isPending}
-            variant="outline"
-            size="sm"
-          >
-            {addPasskeyMutation.isPending ? "adding..." : "add passkey"}
-          </Button>
-        </div>
-      </MethodCard>
-    </div>
+        </MethodCard>
+
+        <MethodCard
+          title="passkeys"
+          status={passkeys.length > 0 ? `${passkeys.length} linked` : "missing"}
+        >
+          <div className="space-y-2">
+            {passkeys.length > 0 ? (
+              passkeys.map((passkey) => (
+                <div
+                  key={passkey.id}
+                  className="border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)] bg-muted/30 p-3 flex items-center justify-between gap-3"
+                >
+                  <span className="text-sm truncate">{passkey.name || "Passkey"}</span>
+                  <Button
+                    onClick={() => setPasskeyToDelete(passkey)}
+                    disabled={removePasskeyMutation.isPending}
+                    variant="outline"
+                    size="sm"
+                  >
+                    remove
+                  </Button>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">No passkeys registered yet.</p>
+            )}
+            <Input
+              type="text"
+              value={passkeyName}
+              onChange={(event) => setPasskeyName(event.target.value)}
+              placeholder="Passkey name, e.g. Work laptop"
+            />
+            <Button
+              onClick={() => addPasskeyMutation.mutate()}
+              disabled={addPasskeyMutation.isPending}
+              variant="outline"
+              size="sm"
+            >
+              {addPasskeyMutation.isPending ? "adding..." : "add passkey"}
+            </Button>
+          </div>
+        </MethodCard>
+      </div>
+      <ConfirmDialog
+        open={!!passkeyToDelete}
+        onOpenChange={(open) => {
+          if (!open) setPasskeyToDelete(null);
+        }}
+        title="Remove passkey"
+        description={`Remove ${passkeyToDelete?.name || "this passkey"} from your account? You will no longer be able to use it to sign in.`}
+        confirmLabel="remove"
+        variant="destructive"
+        onConfirm={() => {
+          if (passkeyToDelete) {
+            removePasskeyMutation.mutate(passkeyToDelete.id);
+          }
+        }}
+        isPending={removePasskeyMutation.isPending}
+      />
+    </>
   );
 }
 
@@ -474,6 +517,7 @@ function SecurityTab({ user }: { user: { email?: string; isAnonymous?: boolean |
     },
     onSuccess: async () => {
       queryClient.setQueryData(["session"], null);
+      queryClient.removeQueries({ queryKey: ["passkeys"] });
       await queryClient.invalidateQueries({ queryKey: ["session"] });
       navigate({ to: "/", replace: true });
     },

--- a/examples/auth.everything.dev/ui/src/routes/_layout/login.tsx
+++ b/examples/auth.everything.dev/ui/src/routes/_layout/login.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Navigate, redirect, useNavigate } from "@tanstack/react-router";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { sessionQueryOptions, useAuthClient } from "@/app";
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,10 @@ type SearchParams = {
 };
 
 type AuthMethod = "near" | "email" | "phone" | "passkey" | "anonymous" | "github";
+
+type ConditionalPublicKeyCredential = typeof PublicKeyCredential & {
+  isConditionalMediationAvailable?: () => Promise<boolean>;
+};
 
 export const Route = createFileRoute("/_layout/login")({
   ssr: false,
@@ -38,6 +42,26 @@ export const Route = createFileRoute("/_layout/login")({
   component: LoginPage,
 });
 
+function getPasskeySupportError() {
+  if (typeof window === "undefined") {
+    return "Passkeys are only available in the browser.";
+  }
+  if (!window.isSecureContext) {
+    return "Passkeys require HTTPS or localhost.";
+  }
+  if (!("PublicKeyCredential" in window)) {
+    return "This browser does not support passkeys.";
+  }
+  return null;
+}
+
+function getPublicKeyCredentialConstructor() {
+  if (typeof window === "undefined" || !("PublicKeyCredential" in window)) {
+    return null;
+  }
+  return window.PublicKeyCredential as ConditionalPublicKeyCredential;
+}
+
 function LoginPage() {
   const navigate = useNavigate();
   const auth = useAuthClient();
@@ -55,19 +79,21 @@ function LoginPage() {
 
   const [isPending, setIsPending] = useState(false);
   const queryClient = useQueryClient();
+  const passkeySupportError = authMethod === "passkey" ? getPasskeySupportError() : null;
 
-  const handleSuccess = async (message: string) => {
+  const handleSuccess = useCallback(async (message: string) => {
     const redirectTo = redirect?.startsWith("/") ? redirect : "/home";
     toast.success(message);
+    queryClient.removeQueries({ queryKey: ["passkeys"] });
     const { data: freshSession } = await auth.getSession();
     if (freshSession) {
       queryClient.setQueryData(["session"], freshSession);
     }
     await queryClient.invalidateQueries({ queryKey: ["session"] });
     navigate({ to: redirectTo, replace: true, search: {} });
-  };
+  }, [auth, navigate, queryClient, redirect]);
 
-  const handleError = (error: { code?: string; message?: string } | Error) => {
+  const handleError = useCallback((error: { code?: string; message?: string } | Error) => {
     const code = "code" in error ? error.code : undefined;
     const message = "message" in error ? error.message : "Failed to sign in";
 
@@ -80,7 +106,50 @@ function LoginPage() {
     } else {
       toast.error(message || "Failed to sign in");
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (authMethod !== "passkey" || session?.user || getPasskeySupportError()) {
+      return;
+    }
+
+    let isActive = true;
+
+    void (async () => {
+      const credential = getPublicKeyCredentialConstructor();
+      const isConditionalAvailable = await credential?.isConditionalMediationAvailable?.();
+      if (!isConditionalAvailable || !isActive) {
+        return;
+      }
+
+      let callbackHandled = false;
+      const result = await auth.signIn.passkey({
+        autoFill: true,
+        fetchOptions: {
+          onSuccess: async () => {
+            if (!isActive) return;
+            callbackHandled = true;
+            await handleSuccess("Signed in with passkey");
+          },
+          onError: (ctx) => {
+            if (!isActive) return;
+            callbackHandled = true;
+            handleError(new Error(ctx.error?.message || "Passkey sign in failed"));
+          },
+        },
+      });
+
+      if (!callbackHandled && result?.error && isActive) {
+        handleError(new Error(result.error.message || "Passkey sign in failed"));
+      }
+    })().catch(() => {
+      // Conditional UI can be dismissed by the browser without a user-facing error.
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [auth, authMethod, handleError, handleSuccess, session?.user]);
 
   const handleNear = async () => {
     setIsPending(true);
@@ -97,23 +166,40 @@ function LoginPage() {
   };
 
   const handlePasskey = async () => {
+    if (passkeySupportError) {
+      toast.error(passkeySupportError);
+      return;
+    }
+
     setIsPending(true);
+    let callbackHandled = false;
     try {
-      await auth.signIn.passkey({
+      const result = await auth.signIn.passkey({
         autoFill: false,
         fetchOptions: {
           onSuccess: async () => {
+            callbackHandled = true;
             setIsPending(false);
             await handleSuccess("Signed in with passkey");
           },
           onError: (ctx) => {
+            callbackHandled = true;
             setIsPending(false);
             handleError(new Error(ctx.error?.message || "Passkey sign in failed"));
           },
         },
       });
-    } catch {
+      if (!callbackHandled && result?.error) {
+        setIsPending(false);
+        handleError(new Error(result.error.message || "Passkey sign in failed"));
+      } else if (!callbackHandled) {
+        setIsPending(false);
+      }
+    } catch (error) {
       setIsPending(false);
+      if (!callbackHandled) {
+        handleError(error instanceof Error ? error : new Error("Passkey sign in failed"));
+      }
     }
   };
 
@@ -283,15 +369,25 @@ function LoginPage() {
       case "passkey":
         return (
           <div className="space-y-6">
-            <UnderConstruction
-              label="passkey"
-              sourceFile="ui/src/routes/_layout/login.tsx"
-              className="mx-auto w-full max-w-xs"
-            />
             <p className="text-xs text-muted-foreground text-center leading-relaxed">
               Use Face ID, Touch ID, or security key
             </p>
-            <Button onClick={handlePasskey} disabled={isPending} className="w-full">
+            <Input
+              type="text"
+              autoComplete="username webauthn"
+              placeholder="email or username"
+              aria-label="Passkey account"
+            />
+            {passkeySupportError && (
+              <p className="text-xs text-destructive text-center leading-relaxed">
+                {passkeySupportError}
+              </p>
+            )}
+            <Button
+              onClick={handlePasskey}
+              disabled={isPending || !!passkeySupportError}
+              className="w-full"
+            >
               {isPending ? "authenticating..." : "sign in with passkey"}
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- Configure explicit WebAuthn relying party settings for Better Auth passkeys.
- Enable passkey sign-in and credential management in the example UI.
- Add passkey option normalization tests and a changeset.

## Test plan
- Not run (commit/PR request only).

Closes #29