### PR TITLE
fix(example): guestbook NEAR guard and relayer balance display

### DIFF
--- a/examples/auth.everything.dev/.env.example
+++ b/examples/auth.everything.dev/.env.example
@@ -1,48 +1,21 @@
-# Environment Variables
-# Copy this file to .env and fill in your values
-#
-# Prerequisites for Docker databases:
-#   docker compose up -d
+# Generated from configured bos secrets
+# Update values as needed for your local environment
 
-# Host Secrets (from template)
-HOST_DATABASE_URL=
-HOST_DATABASE_AUTH_TOKEN=
-BETTER_AUTH_SECRET=
-BETTER_AUTH_URL=
+# app.host
 CORS_ORIGIN=http://localhost:3000
 
-# API Database (PostgreSQL)
-# Docker:  postgresql://everythingdev:everythingdev@localhost:5432/api_db
-# Local dev:  pglite:.bos/api/:memory: (zero-config, no Docker needed)
-API_DATABASE_URL=
+# app.api
+API_DATABASE_URL=postgres://everythingdev:everythingdev@localhost:5432/api_db
 
-# Auth Database (PostgreSQL)
-# Docker:  postgresql://everythingdev:everythingdev@localhost:5433/auth_db
-# Local dev:  pglite:.bos/auth/:memory: (zero-config, no Docker needed)
-AUTH_DATABASE_URL=
-
-# Zephyr Cloud (for deployment)
-ZE_SERVER_TOKEN=
-ZE_USER_EMAIL=
-
-# NEAR (optional - for automated publishing)
-# NEAR_PRIVATE_KEY=ed25519:...
-
-# Registry relay (optional - for sponsored FastKV delegate submission)
-# REGISTRY_RELAY_ACCOUNT_ID=dev.everything.near
-# REGISTRY_RELAY_PRIVATE_KEY=ed25519:...
-# REGISTRY_RELAY_NETWORK=mainnet
-
-# GitHub OAuth
+# app.auth
+AUTH_DATABASE_URL=postgres://everythingdev:everythingdev@localhost:5433/auth_db
+BETTER_AUTH_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+PASSKEY_RP_ID=
+PASSKEY_RP_NAME=
+PASSKEY_ORIGIN=
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
 
-# Passkeys (local dev)
-PASSKEY_RP_ID=localhost
-PASSKEY_RP_NAME=Everything Dev
-PASSKEY_ORIGIN=http://localhost:3000
-
-# Twilio (optional — SMS OTP via phone number auth)
-# TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-# TWILIO_AUTH_TOKEN=
-# TWILIO_PHONE_NUMBER=+1xxxxxxxxxx

--- a/examples/auth.everything.dev/package.json
+++ b/examples/auth.everything.dev/package.json
@@ -18,7 +18,7 @@
       "better-auth": "1.6.9",
       "@better-auth/api-key": "1.6.9",
       "@better-auth/passkey": "1.6.9",
-      "better-near-auth": "1.5.0",
+      "better-near-auth": "1.4.2",
       "every-plugin": "^2.5.11",
       "typescript": "^5.9.3",
       "vitest": "^4.0.17",

--- a/examples/auth.everything.dev/ui/src/components/demo-sections.tsx
+++ b/examples/auth.everything.dev/ui/src/components/demo-sections.tsx
@@ -9,6 +9,7 @@ import {
   Focus,
   Key,
   Loader2,
+  RefreshCw,
   Search,
   ShieldCheck,
   Unlink,
@@ -30,6 +31,7 @@ import {
   Badge,
   Button,
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
@@ -68,17 +70,32 @@ function explorerTxUrl(txHash: string) {
   return `https://near.rocks/tx/${txHash}`;
 }
 
-function formatNear(yoctoNear: string): string {
-  const near = Number(yoctoNear) / 1e24;
+function isYoctoNearAmount(value: string): boolean {
+  return /^\d+$/.test(value.trim());
+}
+
+function formatNear(balance: string): string {
+  const trimmed = balance.trim();
+  if (!trimmed) return "0";
+
+  const near = isYoctoNearAmount(trimmed) ? Number(trimmed) / 1e24 : Number.parseFloat(trimmed);
+
+  if (!Number.isFinite(near)) return trimmed;
   if (near >= 1) return near.toLocaleString(undefined, { maximumFractionDigits: 4 });
-  if (near > 0) return near.toExponential(2);
+  if (near > 0) return near.toLocaleString(undefined, { maximumFractionDigits: 6 });
   return "0";
 }
 
-function hasPositiveYoctoBalance(balance?: string): boolean {
+function hasPositiveNearBalance(balance?: string): boolean {
   if (!balance?.trim()) return false;
+  const trimmed = balance.trim();
+
   try {
-    return BigInt(balance) > 0n;
+    if (isYoctoNearAmount(trimmed)) {
+      return BigInt(trimmed) > 0n;
+    }
+    const near = Number.parseFloat(trimmed);
+    return Number.isFinite(near) && near > 0;
   } catch {
     return false;
   }
@@ -332,7 +349,7 @@ export function ProfileCard({
 
 export function RelayerCard() {
   const [copied, setCopied] = useState(false);
-  const { data, isLoading } = useRelayerInfo();
+  const { data, isLoading, isFetching, refetch } = useRelayerInfo();
 
   const handleCopy = async (text: string) => {
     try {
@@ -386,17 +403,29 @@ export function RelayerCard() {
     );
   }
 
-  const isFunded = hasPositiveYoctoBalance(data.balance);
+  const isFunded = hasPositiveNearBalance(data.balance) || hasPositiveNearBalance(data.available);
   const statusLabel = isFunded ? "Active" : "Unfunded";
   const statusColor = isFunded ? "bg-green-500" : "bg-amber-500";
 
   return (
     <Card>
-      <CardHeader>
+      <CardHeader className="grid grid-cols-[1fr_auto] items-center gap-2">
         <CardTitle className="flex items-center gap-2">
           <Wallet className="h-5 w-5" />
           Relayer
         </CardTitle>
+        <CardAction>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            title="Refresh balance"
+            aria-label="Refresh relayer balance"
+          >
+            <RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+          </Button>
+        </CardAction>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex items-center gap-2">
@@ -770,11 +799,16 @@ export function AccountLinkingCard({ linkedAccounts, user }: { linkedAccounts: a
 
 export function GuestbookCard({ initialGreeting }: { initialGreeting?: string }) {
   const auth = useAuthClient();
+  const { data: session } = useSessionData();
+  const { data: nearAccountsData } = useNearAccountsData(!!session?.user);
   const [newGreeting, setNewGreeting] = useState("");
   const [sendMode, setSendMode] = useState<SendMode>("relay");
   const [relayStatus, setRelayStatus] = useState<RelayStatus>("idle");
   const [relayTxHash, setRelayTxHash] = useState<string | null>(null);
   const queryClient = useQueryClient();
+
+  const hasLinkedNear = Boolean(getActiveNearAccountId(nearAccountsData ?? { accounts: [] }));
+  const canSignGuestbook = hasLinkedNear;
 
   const network = (auth.near.getState()?.networkId || "mainnet") as "mainnet" | "testnet";
   const queryKey = useMemo(() => getGuestbookGreetingQueryKey(network), [network]);
@@ -909,6 +943,10 @@ export function GuestbookCard({ initialGreeting }: { initialGreeting?: string })
   const isPending = isRelaying || isDirecting;
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!canSignGuestbook || !auth.near.getAccountId()) {
+      toast.error("Please connect a NEAR account");
+      return;
+    }
     if (!newGreeting.trim()) return;
     sendMode === "relay" ? addMessageRelay(newGreeting) : addMessageDirect(newGreeting);
   };
@@ -946,13 +984,15 @@ export function GuestbookCard({ initialGreeting }: { initialGreeting?: string })
       <CardContent className="space-y-4">
         <form onSubmit={onSubmit} className="flex gap-2">
           <Input
-            placeholder="Leave a message..."
+            placeholder={
+              canSignGuestbook ? "Leave a message..." : "Connect a NEAR account to sign..."
+            }
             value={newGreeting}
             onChange={(e) => setNewGreeting(e.target.value)}
-            disabled={isPending}
+            disabled={isPending || !canSignGuestbook}
             className="flex-1"
           />
-          <Button type="submit" disabled={isPending || !newGreeting.trim()}>
+          <Button type="submit" disabled={isPending || !newGreeting.trim() || !canSignGuestbook}>
             {isPending ? (
               <div className="flex items-center gap-2">
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -963,6 +1003,16 @@ export function GuestbookCard({ initialGreeting }: { initialGreeting?: string })
             )}
           </Button>
         </form>
+
+        {!canSignGuestbook && (
+          <p className="text-sm text-muted-foreground">
+            Please{" "}
+            <Link to="/accounts" className="text-foreground underline underline-offset-4">
+              connect a NEAR account
+            </Link>{" "}
+            to sign the guestbook.
+          </p>
+        )}
 
         {sendMode === "relay" && relayStatus !== "idle" && (
           <div className="flex items-center gap-2 p-3 border-2 border-outset border-[rgb(51,51,51)] dark:border-[rgb(100,100,100)] bg-muted/50">

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { APIError, createAuthEndpoint, createAuthMiddleware, sessionMiddleware } from "better-auth/api";
 import { setSessionCookie } from "better-auth/cookies";
 import type { Account, BetterAuthPlugin, User, DBAdapter } from "better-auth/types";
-import { Near, generateNonce, generateKey, parseKey, verifyNep413Signature, decodeSignedDelegateAction, InMemoryKeyStore, RotatingKeyStore } from "near-kit";
+import { Near, generateNonce, generateKey, parseKey, verifyNep413Signature, decodeSignedDelegateAction, InMemoryKeyStore, RotatingKeyStore, formatAmount, STORAGE_AMOUNT_PER_BYTE } from "near-kit";
+import type { AccountState } from "near-kit";
 import type { SignedMessage, SignMessageParams, SignedDelegateAction } from "near-kit";
 import { hex, base58 } from "@scure/base";
 import z from "zod";
@@ -230,6 +231,72 @@ async function initRelayer(
 		network,
 		mode: "ephemeral",
 		createdAt: new Date(),
+	};
+}
+
+const RELAYER_BALANCE_PRECISION = 6;
+
+function calculateAvailableBalanceYocto(
+	amount: string,
+	locked: string,
+	storageUsage: number,
+): bigint {
+	const amountBigInt = BigInt(amount);
+	const lockedBigInt = BigInt(locked);
+	const storageRequired = STORAGE_AMOUNT_PER_BYTE * BigInt(storageUsage);
+
+	if (lockedBigInt >= storageRequired) {
+		return amountBigInt;
+	}
+
+	const reservedForStorage = storageRequired - lockedBigInt;
+	if (reservedForStorage >= amountBigInt) {
+		return BigInt(0);
+	}
+
+	return amountBigInt - reservedForStorage;
+}
+
+type RawNearAccountView = {
+	amount: string;
+	locked: string;
+	storage_usage: number;
+	code_hash: string;
+};
+
+async function getRelayerAccountState(
+	near: Near,
+	accountId: string,
+): Promise<AccountState> {
+	const account = await (
+		near as unknown as {
+			rpc: { getAccount: (id: string) => Promise<RawNearAccountView> };
+		}
+	).rpc.getAccount(accountId);
+	const available = calculateAvailableBalanceYocto(
+		account.amount,
+		account.locked,
+		account.storage_usage,
+	);
+	const storageRequired = STORAGE_AMOUNT_PER_BYTE * BigInt(account.storage_usage);
+	const emptyCodeHash = "11111111111111111111111111111111";
+	const balanceFormat = {
+		precision: RELAYER_BALANCE_PRECISION,
+		includeSuffix: false,
+		trimZeros: true,
+	} as const;
+
+	return {
+		balance: formatAmount(account.amount, balanceFormat),
+		available: formatAmount(available.toString(), balanceFormat),
+		staked: formatAmount(account.locked, balanceFormat),
+		storageUsage: formatAmount(storageRequired.toString(), {
+			precision: 4,
+			includeSuffix: false,
+		}),
+		storageBytes: account.storage_usage,
+		hasContract: account.code_hash !== emptyCodeHash,
+		codeHash: account.code_hash,
 	};
 }
 
@@ -1136,17 +1203,26 @@ export const siwn = (options: SIWNPluginOptions): BetterAuthPlugin => {
 						],
 					});
 
-					const network = (nearAccount?.network || "mainnet") as "mainnet" | "testnet";
+					let network = (nearAccount?.network || "mainnet") as "mainnet" | "testnet";
+					if (!nearAccount) {
+						const storedKeys = await ctx.context.adapter.findMany<{ network: string }>({
+							model: "relayerKey",
+						});
+						const storedNetwork = storedKeys?.[0]?.network;
+						if (storedNetwork === "mainnet" || storedNetwork === "testnet") {
+							network = storedNetwork;
+						}
+					}
+
 					const rState = await ensureRelayer(ctx.context.adapter, ctx.context.secret, network);
 
 					if (!rState) {
 						return ctx.json({ enabled: false } satisfies Partial<RelayerInfo> & { enabled: boolean });
 					}
 
-					const near = getNear(network);
-					let account;
+					let account: AccountState;
 					try {
-						account = await near.getAccount(rState.accountId);
+						account = await getRelayerAccountState(rState.near, rState.accountId);
 					} catch {
 						account = {
 							balance: "0",


### PR DESCRIPTION
## Summary
- Block guestbook signing until a NEAR account is linked, with a clear prompt and toast
- Fix relayer funded status and balance display for small amounts (e.g. 0.001 NEAR) by handling NEAR-formatted balances in the UI and using higher-precision RPC formatting in `getRelayerInfo`
- Add a refresh button on the relayer card to re-fetch balance after funding

## Test plan
- [ ] Sign in anonymously without linking NEAR — guestbook Add is disabled with connect prompt
- [ ] Link a NEAR account — guestbook signing works
- [ ] Fund ephemeral relayer with 0.001+ NEAR — Total shows correctly and status is Active after refresh
- [ ] Click relayer refresh — balances and status update without page reload