### PR TITLE
fix: accept optional callbackUrl so redirect-wallet NEP-413 signatures verify

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -439,7 +439,7 @@ export const siwn = (options: SIWNPluginOptions) => {
 					requireRequest: true,
 				},
 				async (ctx) => {
-					const { signedMessage, message, recipient, nonce, accountId } = ctx.body;
+					const { signedMessage, message, recipient, nonce, accountId, callbackUrl } = ctx.body;
 					const network = getNetworkFromAccountId(accountId);
 					const session = ctx.context.session;
 
@@ -456,7 +456,7 @@ export const siwn = (options: SIWNPluginOptions) => {
 
 						const isValid = await verifyNep413Signature(
 						signedMessage,
-						{ message, recipient, nonce: nonceBytes },
+						{ message, recipient, nonce: nonceBytes, callbackUrl },
 							{ near, maxAge: 15 * 60 * 1000 },
 						);
 
@@ -816,6 +816,7 @@ export const siwn = (options: SIWNPluginOptions) => {
 						recipient,
 						nonce,
 						accountId,
+						callbackUrl,
 					} = ctx.body;
 					const network = getNetworkFromAccountId(accountId);
 
@@ -825,7 +826,7 @@ export const siwn = (options: SIWNPluginOptions) => {
 
 						const isValid = await verifyNep413Signature(
 						signedMessage,
-						{ message, recipient, nonce: nonceBytes },
+						{ message, recipient, nonce: nonceBytes, callbackUrl },
 							{ near, maxAge: 15 * 60 * 1000 },
 						);
 

--- a/src/near.test.ts
+++ b/src/near.test.ts
@@ -271,6 +271,22 @@ describe("siwn plugin", () => {
 			expect(error).toBeDefined();
 		});
 
+		it("should pass callbackUrl through to NEP-413 verification (redirect wallets)", async () => {
+			const { verifyNep413Signature } = await import("near-kit");
+			(verifyNep413Signature as any).mockClear();
+			const { client } = await setup();
+
+			const { data, error } = await client.near.verify({
+				...makeVerifyBody(),
+				callbackUrl: "myapp://callback/success",
+			});
+
+			expect(error).toBeNull();
+			expect(data?.success).toBe(true);
+			const params = (verifyNep413Signature as any).mock.calls.at(-1)?.[1];
+			expect(params?.callbackUrl).toBe("myapp://callback/success");
+		});
+
 		it("should detect nonce replay", async () => {
 			const { client } = await setup();
 			const body = makeVerifyBody();

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export const LinkAccountRequest = z.object({
 	recipient: z.string(),
 	nonce: z.string(),
 	accountId: AccountIdSchema,
+	callbackUrl: z.string().optional(),
 });
 
 export const SetPrimaryAccountRequest = z.object({
@@ -80,6 +81,7 @@ export const VerifyRequest = z.object({
 	recipient: z.string(),
 	nonce: z.string(),
 	accountId: AccountIdSchema,
+	callbackUrl: z.string().optional(),
 });
 
 export const RelayRequest = z.object({


### PR DESCRIPTION
## Problem

Redirect-based web wallets include the `callbackUrl` **inside the signed NEP-413 payload**. MyNearWallet's full-page flow (the only option on mobile, where there's no `window.opener`) does this explicitly: [`SignMessageWrapper` passes `callbackUrl` into the signed message when there's no opener](https://github.com/mynearwallet/my-near-wallet/blob/master/packages/frontend/src/routes/SignMessageWrapper.js), and `messageToSign` serializes it as `callbackUrl: Option<string>`.

But `/near/verify` and `/near/link-account` reconstruct the payload with `callbackUrl: null`, so **signatures produced by redirect wallets can never verify** — which currently blocks mobile apps (Flutter/native) from doing Sign-in-with-NEAR through a wallet.

## Fix

- Add an optional `callbackUrl` field to `VerifyRequest` / `LinkAccountRequest`
- Pass it through to `verifyNep413Signature` (near-kit's `serializeNep413Message` already supports it)

Backward compatible: popup/extension flows don't include the field and are unaffected. Test added; `pnpm typecheck` and all 36 tests pass.

## Context

I hit this while building the Flutter demo for [near_dart#5](https://github.com/0xjesus/near_dart/issues/5) — the full SIWN flow (nonce → NEP-413 sign → verify → session) already works against `nearbuilders.org/api` when signing locally with a full-access key; this fix is what's needed for the *wallet-redirect* variant on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)