### PR TITLE
fix: notify $sessionSignal after signIn.near and near.link

### DIFF
--- a/.changeset/notify-session-signal.md
+++ b/.changeset/notify-session-signal.md
@@ -1,0 +1,5 @@
+---
+"better-near-auth": patch
+---
+
+fix: notify session signal after signIn.near and near.link to trigger automatic session refetch

--- a/src/client.ts
+++ b/src/client.ts
@@ -360,7 +360,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 			activeNetwork,
 		}),
 
-		getActions: ($fetch: BetterFetch, _$store: ClientStore, _options: unknown): SIWNClientActions => {
+		getActions: ($fetch: BetterFetch, $store: ClientStore, _options: unknown): SIWNClientActions => {
 			void initClient($fetch);
 
 			return {
@@ -483,6 +483,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 							}
 
 							callbacks?.onSuccess?.();
+							$store.notify("$sessionSignal");
 						} catch (error) {
 							const err = error instanceof Error ? error : new Error(String(error));
 							callbacks?.onError?.(err);
@@ -616,6 +617,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 							}
 
 							callbacks?.onSuccess?.();
+							$store.notify("$sessionSignal");
 						} catch (error) {
 							const err = error instanceof Error ? error : new Error(String(error));
 							callbacks?.onError?.(err);


### PR DESCRIPTION
## Problem

`signIn.near()` and `near.link()` are custom actions returned by `getActions()` — they bypass the proxy entirely, so `atomListeners` never fire. After successful sign-in or account linking, the session atom is never notified, meaning `useSession()` and React Query caches never know to refetch. Every app using `signIn.near()` has to manually call `getSession()` + `setQueryData` in the `onSuccess` callback.

## Fix

Call `$store.notify(":$sessionSignal")` after successful sign-in verification and account linking. This follows the exact same pattern as the official `oauth-popup` plugin (`notifySessionSignal`), which faces the same proxy bypass issue for its custom `signIn.popup` action.

## Changes

| File | Change |
|---|---|
| `src/client.ts:363` | Rename `_$store` → `$store` |
| `src/client.ts:486` | Add `$store.notify("\$sessionSignal")` after `near.link()` success |
| `src/client.ts:620` | Add `$store.notify("\$sessionSignal")` after `signIn.near()` success |