### PR TITLE
fix: clear NEAR wallet state when session ends

### DIFF
--- a/.changeset/reset-near-state-on-signout.md
+++ b/.changeset/reset-near-state-on-signout.md
@@ -1,0 +1,5 @@
+---
+"better-near-auth": patch
+---
+
+fix: clear NEAR wallet state when session ends and reset session restore flag on disconnect

--- a/src/client.ts
+++ b/src/client.ts
@@ -363,6 +363,21 @@ export const siwnClient = (config: SIWNClientConfig) => {
 		getActions: ($fetch: BetterFetch, $store: ClientStore, _options: unknown): SIWNClientActions => {
 			void initClient($fetch);
 
+			const sessionAtom = $store.atoms?.session;
+			if (sessionAtom) {
+				sessionAtom.subscribe(() => {
+					const sessionData = sessionAtom.get()?.data ?? null;
+					if (sessionData === null) {
+						for (const [_net, conn] of connectors) {
+							void conn?.disconnect().catch(() => {});
+						}
+						walletConnected.set(false);
+						nearState.set(null);
+						sessionRestored = false;
+					}
+				});
+			}
+
 			return {
 				near: {
 					nonce: async (params: NonceRequestT, fetchOptions?: BetterFetchOption) => {
@@ -453,6 +468,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 						}
 						walletConnected.set(false);
 						nearState.set(null);
+						sessionRestored = false;
 					},
 					link: async (callbacks?: AuthCallbacks) => {
 						const net = activeNetwork.get();


### PR DESCRIPTION
## Problem

After signing in with a NEAR wallet, signing out, then signing in as anonymous, the UI still shows the old NEAR account. The `nearState` and `walletConnected` atoms are never reset when the better-auth session changes, because:

1. **No session lifecycle hook** — the plugin never subscribes to the session atom, so it can't react to sign-out.
2. **`sessionRestored` is one-shot** — once set to `true`, `restoreFromSession` never re-runs, even after `disconnect()` clears `nearState`. A subsequent sign-in can't re-restore (or clear) NEAR state correctly.

## Fix (`src/client.ts`)

1. **Subscribe to `$store.atoms.session`** in `getActions`. When session data goes to `null` (sign-out), automatically disconnect all connectors and clear `walletConnected`, `nearState`, and `sessionRestored`. This mirrors the better-auth session lifecycle — no manual `disconnect()` call needed.

2. **Reset `sessionRestored = false` in `disconnect()`** so `restoreFromSession` can re-run on the next sign-in.

```ts
// getActions
const sessionAtom = $store.atoms?.session;
if (sessionAtom) {
    sessionAtom.subscribe(() => {
        const sessionData = sessionAtom.get()?.data ?? null;
        if (sessionData === null) {
            for (const [_net, conn] of connectors) {
                void conn?.disconnect().catch(() => {});
            }
            walletConnected.set(false);
            nearState.set(null);
            sessionRestored = false;
        }
    });
}
```

## Verification

- `bun run typecheck` passes
- All 61 tests pass (`bun run test`)