### PR TITLE
feat: accept ml-dsa-65 NEP-413 signatures in SIWN verify endpoints

### DIFF
--- a/.changeset/get-account-id-session-fallback.md
+++ b/.changeset/get-account-id-session-fallback.md
@@ -1,0 +1,13 @@
+---
+"better-near-auth": patch
+---
+
+fix: `getAccountId()` returns the primary SIWN-linked account before NearConnect initializes; `setPrimaryAccount()` now refreshes the session's `nearAccount`
+
+`authClient.near.getAccountId()` previously returned `null` on a fresh page load after a SIWN sign-in until `restoreFromSession` populated the wallet atom — that path dynamically imports `@hot-labs/near-connect` and hits `/near/list-accounts`, which lags behind the better-auth session fetch. UI that read `getAccountId()` for display (dashboard identity, connected-wallet indicator, onramp destination) showed "Connect a NEAR wallet" despite the user being authenticated.
+
+The server plugin already attaches the primary SIWN-linked account to the session response as `session.user.nearAccount` (via an `after` hook on `GET /auth/session` that selects `isPrimary === true` from the `nearAccount` table). `getAccountId()` now reads that field as a fallback, so it returns the user's identity as soon as the session resolves and before NearConnect is initialized. The live NearConnect connection still takes precedence when present, so `getState()`/`isWalletConnected()` callers can distinguish a live signing connection from a session-only identity exactly as before.
+
+`setPrimaryAccount()` now also notifies `$sessionSignal` after a successful primary change so the session's `nearAccount` is re-fetched and reflects the new primary. Previously the field could stay stale until the next unrelated session fetch.
+
+Downstream consumers that hand-rolled `getNearAccountId(linkedAccounts)` workarounds (splitting the `:network` suffix off the core `account` table row) can now rely on `getAccountId()` directly. `session.user.nearAccount` is also available for cases where the public API is too narrow — note that this field is populated by an `after` hook and is therefore not part of the inferred session user type; consumers that want strict typing can narrow it with a small cast (the example app exposes a `readNearAccountId(session)` helper for this).

--- a/.changeset/support-ml-dsa-65-signatures.md
+++ b/.changeset/support-ml-dsa-65-signatures.md
@@ -1,0 +1,7 @@
+---
+"better-near-auth": patch
+---
+
+Fix ML-DSA-65 NEP-413 signed messages being rejected by the SIWN endpoints (`/api/auth/near/verify` and `/api/auth/near/link-account`). Wallets holding post-quantum `ml-dsa-65:` (FIPS 204) full-access keys can now complete Sign in with NEAR — previously they returned `401 Unauthorized: Invalid signature` because `near-kit`'s `verifyNep413Signature` is hardcoded to Ed25519.
+
+Adds a sibling `verifyMlDsa65Nep413Signature` helper that handles the `ml-dsa-65:` key type via `@noble/post-quantum`, reusing the same NEP-413 SHA-256 + borsh payload format and the same timestamp-based maxAge check. The post-quantum branch hits the same `near.getAccessKey` defense-in-depth as the ed25519 path, so the key still has to be a real full-access key on the claimed account. Bumps `near-kit` to `^0.19.0` so `getAccessKey` understands the `ml-dsa-65:` and `ml-dsa-65-hash:` prefixes on the RPC side.

--- a/.changeset/support-ml-dsa-65-signatures.md
+++ b/.changeset/support-ml-dsa-65-signatures.md
@@ -5,3 +5,5 @@
 Fix ML-DSA-65 NEP-413 signed messages being rejected by the SIWN endpoints (`/api/auth/near/verify` and `/api/auth/near/link-account`). Wallets holding post-quantum `ml-dsa-65:` (FIPS 204) full-access keys can now complete Sign in with NEAR — previously they returned `401 Unauthorized: Invalid signature` because `near-kit`'s `verifyNep413Signature` is hardcoded to Ed25519.
 
 Adds a sibling `verifyMlDsa65Nep413Signature` helper that handles the `ml-dsa-65:` key type via `@noble/post-quantum`, reusing the same NEP-413 SHA-256 + borsh payload format and the same timestamp-based maxAge check. The post-quantum branch hits the same `near.getAccessKey` defense-in-depth as the ed25519 path, so the key still has to be a real full-access key on the claimed account. Bumps `near-kit` to `^0.19.0` so `getAccessKey` understands the `ml-dsa-65:` and `ml-dsa-65-hash:` prefixes on the RPC side.
+
+> **Dependency note:** `near-kit` 0.19 pulls in `@napi-rs/keyring` (a native module) and `tar`. Serverless bundlers (e.g. Vercel/Netlify functions, Lambda) may need the native binding marked as an external or included in the bundle — verify your deploy target after upgrading.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install better-near-auth
                 recipient: "myapp.com",
 
                 // Optional: enable gasless relay (ephemeral mode by default)
-                relayer: true,
+                relayer: {},
             }),
         ],
     });
@@ -237,6 +237,8 @@ When `accountId` is not set, an ED25519 keypair is generated on first startup, t
 
 If `accountId` is set but no `privateKey` is provided, the SIWN plugin logs a warning and falls back to ephemeral mode.
 
+> **Validation:** `relayer` is parsed with Zod at plugin construction. Invalid configs throw `BetterAuthError` at startup — hybrid shapes (mixing `mainnet`/`testnet` keys with top-level security fields), unknown keys, and non-integer `maxGasPerTransaction` / `maxDepositPerTransaction` are all rejected. Use either a flat `RelayerConfig` or a `RelayerDualNetworkConfig`, never both.
+
 ### Client Options
 
 | Option | Type | Default | Description |
@@ -291,7 +293,7 @@ If `accountId` is set but no `privateKey` is provided, the SIWN plugin logs a wa
 - `nonce(params)` — Request a nonce from the server
 - `verify(params)` — Verify an auth token with the server
 - `getProfile(accountId?)` — Get user profile (near-kit profile lookup → NEAR Social fallback)
-- `getAccountId()` — Currently connected account ID
+- `getAccountId()` — The user's NEAR account ID. Prefers the live NearConnect connection; falls back to the primary SIWN-linked account from the session (`session.user.nearAccount`) so the value is available as soon as the session resolves, before NearConnect is initialized.
 - `getState()` — Current wallet state
 - `disconnect()` — Disconnect wallet and clear cached data
 - `link(callbacks?)` — Link a NEAR account to the current session
@@ -377,7 +379,7 @@ export const auth = betterAuth({
       apiKey: process.env.FASTNEAR_API_KEY,
 
       // Ephemeral mode (simplest)
-      relayer: true,
+      relayer: {},
 
       // OR explicit mode (privateKey provided directly)
       relayer: {

--- a/README.md
+++ b/README.md
@@ -434,6 +434,9 @@ The plugin detects the network from the account ID:
 - FAK scoped to recipient contract for delegate actions
 - Configurable validation for limited access keys
 
+### Post-Quantum Keys
+- `ml-dsa-65:` (FIPS 204) full-access keys are accepted on `/api/auth/near/verify` and `/api/auth/near/link-account`. Signature verification is delegated to `@noble/post-quantum`'s `ml_dsa65.verify`, while the on-chain access-key check stays the same as ed25519. The NEP-413 SHA-256 + borsh payload format is unchanged from the ed25519 path.
+
 ## Troubleshooting
 
 | Issue | Solution |

--- a/examples/auth.everything.dev/bos.config.json
+++ b/examples/auth.everything.dev/bos.config.json
@@ -13,8 +13,10 @@
     "ui": {
       "name": "ui",
       "development": "local:ui",
-      "production": "https://elliot-braem-7444-ui-better-near-auth-elliotbraem-858f84543-ze.zephyrcloud.app",
-      "integrity": "sha384-6bNcKiFFu8+QFxorj0pSJa9ZMBE0Jmp/QKmyrGx5fj0AJKrp+h32aBbhm2UzSAjc"
+      "production": "https://elliot-braem-7537-ui-better-near-auth-elliotbraem-7ebfb0df4-ze.zephyrcloud.app",
+      "integrity": "sha384-cahPXaG978mInAAPkxhqn0PiHmoXLroWlzS8CNSiduwNnNW5PmLNJMQH3IjeozMe",
+      "ssr": "https://elliot-braem-7541-ui-better-near-auth-elliotbraem-1b8ea89fa-ze.zephyrcloud.app",
+      "ssrIntegrity": "sha384-QjcVI2DezOc1NUdKLv2+orqYInPpcScu0DTEsSlyJWc0aB6Xuzwyxp0cvxw04vqJ"
     },
     "api": {
       "name": "api",
@@ -22,14 +24,14 @@
       "secrets": [
         "API_DATABASE_URL"
       ],
-      "production": "https://elliot-braem-7446-api-better-near-auth-elliotbrae-a709b7ee8-ze.zephyrcloud.app",
-      "integrity": "sha384-KFAcoz3IVC4MTgpHXTz426WjGVBDeTitnM8hMow4cNwSaWmIuizucwCmwJ4ufKNz"
+      "production": "https://elliot-braem-7540-api-better-near-auth-elliotbrae-a682393a7-ze.zephyrcloud.app",
+      "integrity": "sha384-6PBOyGjZGoaCR02gODTN1sApm497povQxfzob6ICNrVsrWFud9xbOOSjBAWYSbzW"
     },
     "auth": {
       "name": "everything-dev_auth-plugin",
       "development": "local:plugins/auth",
-      "production": "https://elliot-braem-7388-everything-dev-auth-plugin-bett-b5d21a026-ze.zephyrcloud.app",
-      "integrity": "sha384-/61E52kHlbhBnZyjgQ0oXsIbIPt8FaJ4STFe09tFoG/mTcwMetm4E0RTYNhAjzpj",
+      "production": "https://elliot-braem-7538-everything-dev-auth-plugin-bett-6a8b025fb-ze.zephyrcloud.app",
+      "integrity": "sha384-5PFfr4JQZMd0pU09YVbT40T6vnZe11uknYWkR6K22lRdykFvVang3XTHdreKdVsm",
       "variables": {
         "socialProviders": {
           "github": {},
@@ -44,11 +46,7 @@
             "mainnet": "auth.everything.near",
             "testnet": "dev.allthethings.testnet"
           },
-          "relayer": {
-            "mainnet": {
-              "accountId": ""
-            }
-          }
+          "relayer": false
         }
       },
       "secrets": [
@@ -69,6 +67,8 @@
     }
   },
   "plugins": {
-    "auth": {}
+    "auth": {
+      "development": "local:plugins/auth"
+    }
   }
 }

--- a/examples/auth.everything.dev/package.json
+++ b/examples/auth.everything.dev/package.json
@@ -12,7 +12,7 @@
       "react-dom": "19.2.4",
       "@tanstack/react-query": "5.90.20",
       "@tanstack/react-router": "1.157.16",
-      "near-kit": "^0.14.0",
+      "near-kit": "^0.19.0",
       "@scure/base": "^2.2.0",
       "drizzle-orm": "^0.45.1",
       "drizzle-kit": "^0.31.8",

--- a/examples/auth.everything.dev/package.json
+++ b/examples/auth.everything.dev/package.json
@@ -19,7 +19,7 @@
       "better-auth": "1.6.25",
       "@better-auth/api-key": "1.6.25",
       "@better-auth/passkey": "1.6.25",
-      "better-near-auth": "1.10.1",
+      "better-near-auth": "1.10.2",
       "every-plugin": "^2.10.1",
       "typescript": "^5.9.3",
       "vitest": "^4.1.8",

--- a/examples/auth.everything.dev/plugins/auth/rspack.config.js
+++ b/examples/auth.everything.dev/plugins/auth/rspack.config.js
@@ -34,7 +34,7 @@ export default shouldDeploy
   ? withZephyr({
       hooks: {
         onDeployComplete: async (info) => {
-          console.log("🚀 Plugin Deployed:", info.url);
+          console.log("🚀 Auth Deployed:", info.url);
           const integrity = await computeSriHashForUrl(info.url);
           const key = findPluginKey(bosConfigPath, __dirname);
           if (key) {
@@ -42,8 +42,8 @@ export default shouldDeploy
               url: info.url,
               integrity,
               bosConfigPath,
-              urlField: `plugins.${key}.production`,
-              integrityField: `plugins.${key}.integrity`,
+              urlField: `app.${key}.production`,
+              integrityField: `app.${key}.integrity`,
             });
           }
         },

--- a/examples/auth.everything.dev/ui/src/components/demo-sections.tsx
+++ b/examples/auth.everything.dev/ui/src/components/demo-sections.tsx
@@ -40,7 +40,7 @@ import {
   CardTitle,
 } from "@/components";
 import { Input } from "@/components/ui/input";
-import { getLinkedProviders, getNearAccountId } from "@/lib/auth";
+import { readNearAccountId } from "@/lib/auth";
 import { relayHistoryQueryKey } from "@/lib/query-keys";
 import { NearProfile } from "./near-profile";
 import RelayFeed from "./relay-feed";
@@ -151,10 +151,6 @@ async function unlinkNearAccount(
     accountId,
     network: account.network,
   });
-}
-
-export function getActiveNearAccountId(data: { accounts: ListedNearAccount[] }) {
-  return getNearAccountId(data.accounts);
 }
 
 export function useNearAccountsData(enabled = true) {
@@ -819,14 +815,13 @@ export function AccountLinkingCard({
 
 export function GuestbookCard({ initialGreeting }: { initialGreeting?: string }) {
   const auth = useAuthClient();
-  const { data: nearAccountsData } = useNearAccountsData(!!auth.near.getAccountId());
   const [newGreeting, setNewGreeting] = useState("");
   const [sendMode, setSendMode] = useState<SendMode>("relay");
   const [relayStatus, setRelayStatus] = useState<RelayStatus>("idle");
   const [relayTxHash, setRelayTxHash] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
-  const hasLinkedNear = Boolean(getActiveNearAccountId(nearAccountsData ?? { accounts: [] }));
+  const hasLinkedNear = !!auth.near.getAccountId();
   const canSignGuestbook = hasLinkedNear;
 
   const network = auth.useActiveNetwork();
@@ -1302,8 +1297,8 @@ export function useWorkspaceData(session: SessionData | null | undefined) {
   const greetingQuery = useGuestbookGreeting(!!session?.user);
   const relayerQuery = useRelayerInfo();
   const linkedAccounts = nearAccountsQuery.data?.accounts ?? [];
-  const nearAccountId = getNearAccountId(linkedAccounts);
-  const linkedProviders = getLinkedProviders(linkedAccounts);
+  const nearAccountId = readNearAccountId(session);
+  const linkedProviders = linkedAccounts.length > 0 ? ["siwn"] : [];
 
   return {
     linkedAccounts,

--- a/examples/auth.everything.dev/ui/src/lib/auth.ts
+++ b/examples/auth.everything.dev/ui/src/lib/auth.ts
@@ -71,58 +71,6 @@ function getAuthVariables(config?: Partial<ClientRuntimeConfig>): RuntimeAuthVar
   return runtimeConfig.auth.variables;
 }
 
-function getProviderId(account: {
-  providerId?: unknown;
-  accountId?: unknown;
-  network?: unknown;
-}): string {
-  if (typeof account.providerId === "string" && account.providerId.length > 0) {
-    return account.providerId;
-  }
-
-  if (
-    typeof account.accountId === "string" &&
-    (account.network === "mainnet" || account.network === "testnet")
-  ) {
-    return "siwn";
-  }
-
-  return "unknown";
-}
-
-export function getAccountProviderId(account: {
-  providerId?: unknown;
-  accountId?: unknown;
-  network?: unknown;
-}): string {
-  return getProviderId(account);
-}
-
-export function getNearAccountId(
-  linkedAccounts: Array<{ providerId?: unknown; accountId?: unknown; network?: unknown }>,
-): string | null {
-  if (!Array.isArray(linkedAccounts)) {
-    return null;
-  }
-
-  const nearAccount = linkedAccounts.find((account) => getProviderId(account) === "siwn");
-  if (typeof nearAccount?.accountId !== "string") {
-    return null;
-  }
-
-  return nearAccount.accountId.split(":")[0] || null;
-}
-
-export function getLinkedProviders(
-  linkedAccounts: Array<{ providerId?: unknown; accountId?: unknown; network?: unknown }>,
-): string[] {
-  if (!Array.isArray(linkedAccounts)) {
-    return [];
-  }
-
-  return [...new Set(linkedAccounts.map((account) => getProviderId(account)))];
-}
-
 function getSiwnClientConfig(options: CreateAuthClientOptions): SiwnClientConfig {
   const runtimeConfig = readRuntimeConfig(options.runtimeConfig);
   const variables = getAuthVariables(options.runtimeConfig);
@@ -186,6 +134,13 @@ type PasskeyListResult = Awaited<ReturnType<AuthClient["passkey"]["listUserPassk
 export type SessionData = AuthClient["$Infer"]["Session"];
 export type Organization = NonNullable<OrganizationListResult["data"]>[number];
 export type Passkey = NonNullable<PasskeyListResult["data"]>[number];
+
+export function readNearAccountId(session: SessionData | null | undefined): string | null {
+  const nearAccount = (
+    session?.user as { nearAccount?: { accountId?: unknown } } | null | undefined
+  )?.nearAccount;
+  return typeof nearAccount?.accountId === "string" ? nearAccount.accountId : null;
+}
 
 export function useAuthClient(): AuthClient {
   return useRouter().options.context.authClient;

--- a/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/home.tsx
+++ b/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/home.tsx
@@ -2,12 +2,8 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Clock, Key, Link2, Search, ShieldCheck, UserRound, Zap } from "lucide-react";
 import { sessionQueryOptions } from "@/app";
 import { Badge, Button, Card, CardContent } from "@/components";
-import {
-  getActiveNearAccountId,
-  StatCard,
-  useSessionData,
-  useWorkspaceData,
-} from "@/components/demo-sections";
+import { StatCard, useSessionData, useWorkspaceData } from "@/components/demo-sections";
+import { readNearAccountId } from "@/lib/auth";
 
 export const Route = createFileRoute("/_layout/_authenticated/home")({
   head: () => ({
@@ -88,7 +84,7 @@ function WorkspacePage() {
   const { data: session } = useSessionData();
   const user = session?.user ?? null;
   const workspace = useWorkspaceData(session);
-  const nearAccountId = getActiveNearAccountId({ accounts: workspace.linkedAccounts });
+  const nearAccountId = readNearAccountId(session);
 
   return (
     <div className="space-y-6">

--- a/package.json
+++ b/package.json
@@ -60,9 +60,10 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@noble/post-quantum": "^0.6.1",
     "@scure/base": "^2.2.0",
     "nanostores": "^1.1.0",
-    "near-kit": "^0.14.0",
+    "near-kit": "^0.19.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@noble/post-quantum':
+        specifier: ^0.6.1
+        version: 0.6.1
       '@scure/base':
         specifier: ^2.2.0
         version: 2.2.0
@@ -15,8 +18,8 @@ importers:
         specifier: ^1.1.0
         version: 1.3.0
       near-kit:
-        specifier: ^0.14.0
-        version: 0.14.0(@hot-labs/near-connect@0.11.4)
+        specifier: ^0.19.0
+        version: 0.19.0(@hot-labs/near-connect@0.11.4)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1177,6 +1180,10 @@ packages:
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/post-quantum@0.6.1':
+    resolution: {integrity: sha512-+pormrDZwjRw05U8ADK4JpHejo87+gBd+muRBB/ozztH5yhDLMDF4jHQWN3NQQAsu1zBNPWTG0ZwVI0CR29H0A==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1253,8 +1260,8 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
-  '@oxc-project/types@0.142.0':
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+  '@oxc-project/types@0.147.0':
+    resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
@@ -1961,14 +1968,20 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.2.2':
-    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+  '@rolldown/binding-android-arm64@1.2.6':
+    resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1979,8 +1992,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1991,8 +2004,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+  '@rolldown/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2003,8 +2016,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.2.2':
-    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2015,8 +2028,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
-    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2028,8 +2041,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2042,8 +2055,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.2':
-    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2056,8 +2069,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
-    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2070,8 +2083,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.2':
-    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -2084,8 +2097,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2098,8 +2111,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2111,8 +2124,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.2.2':
-    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2128,8 +2141,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.2':
-    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2140,8 +2153,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3787,6 +3800,17 @@ packages:
       '@near-wallet-selector/core':
         optional: true
 
+  near-kit@0.19.0:
+    resolution: {integrity: sha512-O/h6hJ4bLu9IXeSG5VV+f4fpmDPGBggGOpaZJiuMHznZ+0CBQUuE+YhZkTXZ+x7Fp9E0SDPr3eLZgucG2xqT6w==}
+    peerDependencies:
+      '@hot-labs/near-connect': '>=0.11.0'
+      '@near-wallet-selector/core': '>=8.0.0'
+    peerDependenciesMeta:
+      '@hot-labs/near-connect':
+        optional: true
+      '@near-wallet-selector/core':
+        optional: true
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
@@ -4087,8 +4111,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.2.2:
-    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+  rolldown@1.2.6:
+    resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4250,6 +4274,10 @@ packages:
 
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   term-size@2.2.1:
@@ -5456,6 +5484,12 @@ snapshots:
 
   '@noble/hashes@2.2.0': {}
 
+  '@noble/post-quantum@0.6.1':
+    dependencies:
+      '@noble/ciphers': 2.2.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5569,7 +5603,7 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
-  '@oxc-project/types@0.142.0': {}
+  '@oxc-project/types@0.147.0': {}
 
   '@petamoriken/float16@3.9.3':
     optional: true
@@ -6332,76 +6366,79 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.2.2':
+  '@rolldown/binding-android-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.2':
+  '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.2':
+  '@rolldown/binding-darwin-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.2':
+  '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.2':
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.2':
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.2':
+  '@rolldown/binding-linux-x64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.2':
+  '@rolldown/binding-openharmony-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.1':
@@ -6414,13 +6451,13 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.1':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.2':
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
@@ -8164,6 +8201,21 @@ snapshots:
     optionalDependencies:
       '@hot-labs/near-connect': 0.11.4
 
+  near-kit@0.19.0(@hot-labs/near-connect@0.11.4):
+    dependencies:
+      '@napi-rs/keyring': 1.3.0
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 2.2.0
+      '@noble/post-quantum': 0.6.1
+      '@scure/base': 2.2.0
+      '@scure/bip32': 2.2.0
+      '@scure/bip39': 2.2.0
+      '@zorsh/zorsh': 0.5.0
+      tar: 7.5.22
+      zod: 4.4.3
+    optionalDependencies:
+      '@hot-labs/near-connect': 0.11.4
+
   neo-async@2.6.2:
     optional: true
 
@@ -8492,7 +8544,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.15.10(rolldown@1.2.2)(typescript@5.9.3):
+  rolldown-plugin-dts@0.15.10(rolldown@1.2.6)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.3
@@ -8502,7 +8554,7 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.3
       get-tsconfig: 4.14.0
-      rolldown: 1.2.2
+      rolldown: 1.2.6
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8546,25 +8598,26 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
 
-  rolldown@1.2.2:
+  rolldown@1.2.6:
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.147.0
       '@rolldown/pluginutils': 1.0.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.2
-      '@rolldown/binding-darwin-arm64': 1.2.2
-      '@rolldown/binding-darwin-x64': 1.2.2
-      '@rolldown/binding-freebsd-x64': 1.2.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
-      '@rolldown/binding-linux-arm64-gnu': 1.2.2
-      '@rolldown/binding-linux-arm64-musl': 1.2.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
-      '@rolldown/binding-linux-s390x-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-musl': 1.2.2
-      '@rolldown/binding-openharmony-arm64': 1.2.2
-      '@rolldown/binding-win32-arm64-msvc': 1.2.2
-      '@rolldown/binding-win32-x64-msvc': 1.2.2
+      '@rolldown/binding-android-arm-eabi': 1.2.6
+      '@rolldown/binding-android-arm64': 1.2.6
+      '@rolldown/binding-darwin-arm64': 1.2.6
+      '@rolldown/binding-darwin-x64': 1.2.6
+      '@rolldown/binding-freebsd-x64': 1.2.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.6
+      '@rolldown/binding-linux-arm64-gnu': 1.2.6
+      '@rolldown/binding-linux-arm64-musl': 1.2.6
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.6
+      '@rolldown/binding-linux-s390x-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-musl': 1.2.6
+      '@rolldown/binding-openharmony-arm64': 1.2.6
+      '@rolldown/binding-win32-arm64-msvc': 1.2.6
+      '@rolldown/binding-win32-x64-msvc': 1.2.6
 
   rollup@4.60.2:
     dependencies:
@@ -8747,6 +8800,14 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   term-size@2.2.1: {}
 
   terser-webpack-plugin@5.5.0(webpack@5.106.2):
@@ -8798,8 +8859,8 @@ snapshots:
       diff: 8.0.4
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.2.2
-      rolldown-plugin-dts: 0.15.10(rolldown@1.2.2)(typescript@5.9.3)
+      rolldown: 1.2.6
+      rolldown-plugin-dts: 0.15.10(rolldown@1.2.6)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.1.2
       tinyglobby: 0.2.16

--- a/scripts/sync-example-version.mjs
+++ b/scripts/sync-example-version.mjs
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 const rootPackage = JSON.parse(readFileSync("package.json", "utf8"));
 const version = rootPackage.version;
 const range = `^${version}`;
+const nearKitRange = rootPackage.dependencies?.["near-kit"] ?? rootPackage.devDependencies?.["near-kit"];
 
 function updateJson(path, update) {
 	const json = JSON.parse(readFileSync(path, "utf8"));
@@ -13,6 +14,9 @@ function updateJson(path, update) {
 updateJson("examples/auth.everything.dev/package.json", (json) => {
 	json.workspaces.catalog["better-near-auth"] = range;
 	json.dependencies["better-near-auth"] = range;
+	if (nearKitRange && json.workspaces?.catalog) {
+		json.workspaces.catalog["near-kit"] = nearKitRange;
+	}
 });
 
 updateJson("examples/auth.everything.dev/plugins/auth/package.json", (json) => {

--- a/skills/client/SKILL.md
+++ b/skills/client/SKILL.md
@@ -25,7 +25,7 @@ Client-side plugin for NEAR wallet authentication and gasless relay. Connects to
 
 `siwnClient()` is SSR-safe. Wallet resources (`NearConnector`, `Near`, event listeners) are lazily initialized on first client-side access — they do not run at construction time. On the server:
 
-- `getAccountId()` returns `null` (no session restore yet)
+- `getAccountId()` returns `null` (no session yet) — once the session resolves on the client, it returns the primary SIWN-linked account (`session.user.nearAccount`) until NearConnect initializes.
 - `getState()` returns `null`
 - `isWalletConnected()` returns `false`
 - `detectNearAccount()` returns `null` (no browser wallet to probe)
@@ -172,7 +172,7 @@ if (detected) {
 
 `detectNearAccount()` silently probes `@hot-labs/near-connect`'s `getConnectedWallet()` across all supported networks — it reads localStorage for previously authorized wallet IDs and queries the wallet extension without showing any UI. Returns `null` if no wallet is found. Use it on login pages to offer a one-click "Continue with NEAR" option.
 
-When the wallet disconnects externally (user signs out from wallet UI), `nearState` preserves `accountId` but clears `publicKey`. Use `isWalletConnected()` to check if signing operations are available, and `getAccountId()` for display purposes (works even when disconnected).
+When the wallet disconnects externally (user signs out from wallet UI), `nearState` preserves `accountId` but clears `publicKey`. Use `isWalletConnected()` to check if signing operations are available, and `getAccountId()` for display purposes. `getAccountId()` returns the live connection when present, then falls back to the primary SIWN-linked account on the session, so it works for display even before NearConnect has been initialized.
 
 ### Sub-account creation
 
@@ -234,7 +234,7 @@ const result = await authClient.near.view({
 | `verify(params)` | `Promise<Response<VerifyResponse>>` | Verify NEP-413 signature |
 | `getProfile(accountId?)` | `Promise<Response<Profile>>` | Get NEAR profile |
 | `view(params)` | `Promise<Response<ViewResponse>>` | Server-side contract view call |
-| `getAccountId()` | `string \| null` | Currently connected account ID (persists across disconnects) |
+| `getAccountId()` | `string \| null` | The user's NEAR account ID. Prefers the live NearConnect connection; falls back to the primary SIWN-linked account on the session (`session.user.nearAccount`). Persists across disconnects. |
 | `getState()` | `{ accountId, publicKey, networkId } \| null` | Wallet state |
 | `isWalletConnected()` | `boolean` | Whether wallet is actively connected |
 | `detectNearAccount()` | `Promise<{ accountId, publicKey, networkId } \| null>` | Silently probe for a previously authorized wallet without prompting |

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -58,7 +58,6 @@ The private key is encrypted with AES-256-GCM using `BETTER_AUTH_SECRET` as the 
 siwn({
   recipient: "myapp.com",
   relayer: {
-    ephemeral: true, // explicit marker (optional)
     whitelistedContracts: ["myapp.near"],
     maxGasPerTransaction: "300000000000000", // 300 Tgas
     maxDepositPerTransaction: "0",

--- a/skills/tanstack/SKILL.md
+++ b/skills/tanstack/SKILL.md
@@ -214,9 +214,11 @@ authClient.near.getNearClient().transaction(accountId)
 ### nearState persists accountId across disconnects
 
 When the wallet disconnects externally:
-- `getAccountId()` still returns the accountId (from session restore)
+- `getAccountId()` still returns the accountId — either the live connection if one is present, or the primary SIWN-linked account from the session
 - `isWalletConnected()` returns false
 - `publicKey` is cleared from state
+
+`getAccountId()` falls back to `session.user.nearAccount` so it returns the user's identity before NearConnect is initialized (e.g. on a fresh page load right after SIWN sign-in, before `restoreFromSession` has populated the wallet atom). Use `isWalletConnected()` or `getState().publicKey` to distinguish a live NearConnect connection from a session-only identity.
 
 This means UI can display the user's NEAR account even when the wallet is disconnected. Signing operations automatically prompt reconnection.
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -410,7 +410,10 @@ export const siwnClient = (config: SIWNClientConfig) => {
 					},
 					getAccountId: () => {
 						const state = nearState.get();
-						return state?.accountId || null;
+						if (state?.accountId) return state.accountId;
+						const sessionData = sessionAtom?.get()?.data ?? null;
+						const nearAcct = (sessionData?.user as { nearAccount?: { accountId?: unknown } } | null | undefined)?.nearAccount;
+						return typeof nearAcct?.accountId === "string" ? nearAcct.accountId : null;
 					},
 					getState: () => nearState.get(),
 					isWalletConnected: () => walletConnected.get(),
@@ -532,6 +535,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 							});
 							activeNetwork.set(activeAccount.network);
 						}
+						$store.notify("$sessionSignal");
 						return response;
 					},
 					buildSignedDelegateAction: async (

--- a/src/client.ts
+++ b/src/client.ts
@@ -534,8 +534,8 @@ export const siwnClient = (config: SIWNClientConfig) => {
 								networkId: activeAccount.network,
 							});
 							activeNetwork.set(activeAccount.network);
+							$store.notify("$sessionSignal");
 						}
-						$store.notify("$sessionSignal");
 						return response;
 					},
 					buildSignedDelegateAction: async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import { BetterAuthError } from "@better-auth/core/error";
 
 import { Near, generateNonce, generateKey, parseKey, verifyNep413Signature, decodeSignedDelegateAction, InMemoryKeyStore } from "near-kit";
 import type { SignedDelegateAction, PrivateKey } from "near-kit";
-import { hex, base58 } from "@scure/base";
+import { hex, base58, base64 } from "@scure/base";
+import { ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
 import z from "zod";
 import { defaultGetProfile, getImageUrl, getNetworkFromAccountId } from "./profile.js";
 import { schema } from "./schema.js";
@@ -329,6 +330,108 @@ async function defaultValidateLimitedAccessKey(
 	return false;
 }
 
+const ML_DSA_65_KEY_PREFIX = "ml-dsa-65:";
+const ML_DSA_65_PUBLIC_KEY_LENGTH = 1952;
+const NEP413_TAG = 2147484061;
+
+function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
+	const total = parts.reduce((sum, p) => sum + p.length, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.length;
+	}
+	return out;
+}
+
+function encodeBorshU32(value: number): Uint8Array {
+	const out = new Uint8Array(4);
+	new DataView(out.buffer).setUint32(0, value, true);
+	return out;
+}
+
+function encodeBorshString(value: string): Uint8Array {
+	const bytes = new TextEncoder().encode(value);
+	return concatUint8Arrays([encodeBorshU32(bytes.length), bytes]);
+}
+
+function serializeNep413Message(params: {
+	message: string;
+	nonce: Uint8Array;
+	recipient: string;
+	callbackUrl?: string;
+}): Uint8Array {
+	if (params.nonce.length !== 32) {
+		throw new Error("Nonce must be exactly 32 bytes");
+	}
+	const tagBytes = encodeBorshU32(NEP413_TAG);
+	const callbackUrlBytes: Uint8Array = params.callbackUrl
+		? concatUint8Arrays([encodeBorshU32(1), encodeBorshString(params.callbackUrl)])
+		: encodeBorshU32(0);
+	const messageBytes = encodeBorshString(params.message);
+	const nonceBytes = params.nonce;
+	const recipientBytes = encodeBorshString(params.recipient);
+	return concatUint8Arrays([tagBytes, messageBytes, nonceBytes, recipientBytes, callbackUrlBytes]);
+}
+
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+	const ab = new ArrayBuffer(u8.byteLength);
+	new Uint8Array(ab).set(u8);
+	return ab;
+}
+
+interface MlDsa65VerifyOptions {
+	near: Near;
+	maxAge?: number;
+}
+
+async function verifyMlDsa65Nep413Signature(
+	signedMessage: { accountId: string; publicKey: string; signature: string },
+	params: {
+		message: string;
+		recipient: string;
+		nonce: Uint8Array;
+		callbackUrl?: string;
+	},
+	options: MlDsa65VerifyOptions,
+): Promise<boolean> {
+	try {
+		const { near, maxAge = 5 * 60 * 1000 } = options;
+
+		if (!signedMessage.publicKey.startsWith(ML_DSA_65_KEY_PREFIX)) {
+			return false;
+		}
+
+		const stripped = signedMessage.publicKey.slice(ML_DSA_65_KEY_PREFIX.length);
+		const publicKeyBytes = base58.decode(stripped);
+		if (publicKeyBytes.length !== ML_DSA_65_PUBLIC_KEY_LENGTH) {
+			return false;
+		}
+
+		if (maxAge !== Infinity && params.nonce.length === 32) {
+			const view = new DataView(params.nonce.buffer, params.nonce.byteOffset, params.nonce.byteLength);
+			const timestamp = Number(view.getBigUint64(0, false));
+			const age = Date.now() - timestamp;
+			if (age > maxAge) return false;
+			if (age < 0) return false;
+		}
+
+		const accessKey = await near.getAccessKey(signedMessage.accountId, signedMessage.publicKey);
+		if (!accessKey || accessKey.permission !== "FullAccess") {
+			return false;
+		}
+
+		const combined = serializeNep413Message(params);
+		const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", toArrayBuffer(combined)));
+
+		const signatureBytes = base64.decode(signedMessage.signature);
+		return ml_dsa65.verify(signatureBytes, hash, publicKeyBytes);
+	} catch {
+		return false;
+	}
+}
+
 function isImplicitAccount(accountId: string): boolean {
 	return /^[0-9a-f]{64}$/.test(accountId);
 }
@@ -555,11 +658,17 @@ export const siwn = (options: SIWNPluginOptions) => {
 						const near = getNear(network);
 						const nonceBytes = hex.decode(nonce);
 
-						const isValid = await verifyNep413Signature(
-						signedMessage,
-						{ message, recipient, nonce: nonceBytes, callbackUrl },
-							{ near, maxAge: 15 * 60 * 1000 },
-						);
+						const isValid = signedMessage.publicKey.startsWith("ml-dsa-65:")
+							? await verifyMlDsa65Nep413Signature(
+								signedMessage,
+								{ message, recipient, nonce: nonceBytes, callbackUrl },
+								{ near, maxAge: 15 * 60 * 1000 },
+							)
+							: await verifyNep413Signature(
+								signedMessage,
+								{ message, recipient, nonce: nonceBytes, callbackUrl },
+								{ near, maxAge: 15 * 60 * 1000 },
+							);
 
 						if (!isValid) {
 							throw new APIError("UNAUTHORIZED", {
@@ -925,11 +1034,17 @@ export const siwn = (options: SIWNPluginOptions) => {
 						const near = getNear(network);
 						const nonceBytes = hex.decode(nonce);
 
-						const isValid = await verifyNep413Signature(
-						signedMessage,
-						{ message, recipient, nonce: nonceBytes, callbackUrl },
-							{ near, maxAge: 15 * 60 * 1000 },
-						);
+						const isValid = signedMessage.publicKey.startsWith("ml-dsa-65:")
+							? await verifyMlDsa65Nep413Signature(
+								signedMessage,
+								{ message, recipient, nonce: nonceBytes, callbackUrl },
+								{ near, maxAge: 15 * 60 * 1000 },
+							)
+							: await verifyNep413Signature(
+								signedMessage,
+								{ message, recipient, nonce: nonceBytes, callbackUrl },
+								{ near, maxAge: 15 * 60 * 1000 },
+							);
 
 						if (!isValid) {
 							throw new APIError("UNAUTHORIZED", {

--- a/src/near.test.ts
+++ b/src/near.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "better-auth/test";
 import { siwn } from "./index.js";
+import { siwnClient } from "./client.js";
 import { SUB_ACCOUNT_LABEL_REGEX } from "./types.js";
 import { hex } from "@scure/base";
+import { atom } from "nanostores";
 
 const MOCK_ACCOUNT_ID = "test.near";
 const MOCK_TESTNET_ACCOUNT_ID = "test.testnet";
@@ -1079,6 +1081,132 @@ describe("siwn plugin", () => {
 				publicKey: "ed25519:testpublickey",
 			});
 			expect(res.status).toBe(503);
+		});
+	});
+});
+
+describe("siwnClient getActions", () => {
+	type SessionAtom = ReturnType<typeof atom<unknown>>;
+
+	function makeSessionStore(initial: unknown) {
+		const sessionAtom = atom<unknown>(initial);
+		const store = {
+			atoms: { session: sessionAtom },
+			notify: vi.fn(),
+			listen: vi.fn(),
+		};
+		return { store, sessionAtom };
+	}
+
+	function setupClient(initial: unknown, $fetchImpl: (path: string, opts?: unknown) => unknown = () => Promise.resolve({ data: null, error: null })) {
+		const plugin = siwnClient({ recipient: MOCK_RECIPIENT });
+		const { store, sessionAtom } = makeSessionStore(initial);
+		const $fetch = vi.fn((path: string, opts?: unknown) => $fetchImpl(path, opts)) as unknown as Parameters<typeof plugin.getActions>[0];
+		const actions = plugin.getActions($fetch, store as unknown as Parameters<typeof plugin.getActions>[1], undefined);
+		return { actions, sessionAtom, plugin, store, $fetch };
+	}
+
+	describe("getAccountId session fallback", () => {
+		it("returns null when there is no session and no NearConnect state", () => {
+			const { actions } = setupClient(null);
+			expect(actions.near.getAccountId()).toBeNull();
+		});
+
+		it("returns the primary nearAccount from session when NearConnect is not connected", () => {
+			const { actions, sessionAtom } = setupClient({
+				data: {
+					user: {
+						id: "user-1",
+						nearAccount: { accountId: "alice.near", network: "mainnet", isPrimary: true },
+					},
+				},
+			});
+			expect(actions.near.getAccountId()).toBe("alice.near");
+			sessionAtom.set({
+				data: {
+					user: { id: "user-1", nearAccount: { accountId: "bob.near", network: "testnet", isPrimary: true } },
+				},
+			});
+			expect(actions.near.getAccountId()).toBe("bob.near");
+		});
+
+		it("returns the live NearConnect account when connected, even if a SIWN-linked account exists", () => {
+			const { actions, plugin } = setupClient({
+				data: {
+					user: {
+						id: "user-1",
+						nearAccount: { accountId: "alice.near", network: "mainnet", isPrimary: true },
+					},
+				},
+			});
+			plugin.getAtoms(undefined as unknown as Parameters<typeof plugin.getAtoms>[0]).nearState.set({
+				accountId: "charlie.near",
+				publicKey: "ed25519:live",
+				networkId: "mainnet",
+			});
+			expect(actions.near.getAccountId()).toBe("charlie.near");
+		});
+
+		it("returns null when the session is cleared", () => {
+			const { actions, sessionAtom } = setupClient({
+				data: {
+					user: { id: "user-1", nearAccount: { accountId: "alice.near", network: "mainnet", isPrimary: true } },
+				},
+			});
+			expect(actions.near.getAccountId()).toBe("alice.near");
+			sessionAtom.set({ data: null });
+			expect(actions.near.getAccountId()).toBeNull();
+		});
+
+		it("returns null when session has a user but no nearAccount (no primary linked)", () => {
+			const { actions } = setupClient({ data: { user: { id: "user-1" } } });
+			expect(actions.near.getAccountId()).toBeNull();
+		});
+
+		it("returns null when nearAccount.accountId is not a string", () => {
+			const { actions } = setupClient({ data: { user: { id: "user-1", nearAccount: { accountId: 123 } } } });
+			expect(actions.near.getAccountId()).toBeNull();
+		});
+	});
+
+	describe("setPrimaryAccount", () => {
+		it("notifies $sessionSignal so the session's nearAccount refreshes", async () => {
+			const fetchResponse = {
+				data: {
+					success: true,
+					accountId: "bob.near",
+					network: "mainnet",
+					message: "ok",
+					accounts: [],
+					activeAccount: {
+						id: "acc-bob",
+						userId: "user-1",
+						accountId: "bob.near",
+						network: "mainnet",
+						publicKey: "ed25519:bob",
+						isPrimary: true,
+						createdAt: new Date(),
+						providerId: "siwn",
+						isActive: true,
+						isAvailable: false,
+					},
+					availableAccounts: [],
+				},
+				error: null,
+			};
+			const { actions, store, plugin } = setupClient(
+				{ data: { user: { id: "user-1", nearAccount: { accountId: "alice.near", network: "mainnet", isPrimary: true } } } },
+				() => Promise.resolve(fetchResponse),
+			);
+
+			await actions.near.setPrimaryAccount({ accountId: "bob.near", network: "mainnet" });
+
+			expect((store.notify as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith("$sessionSignal");
+			expect(plugin.getAtoms(undefined as unknown as Parameters<typeof plugin.getAtoms>[0]).nearState.get()).toEqual({
+				accountId: "bob.near",
+				publicKey: "ed25519:bob",
+				networkId: "mainnet",
+			});
 		});
 	});
 });

--- a/src/near.test.ts
+++ b/src/near.test.ts
@@ -3,8 +3,9 @@ import { getTestInstance } from "better-auth/test";
 import { siwn } from "./index.js";
 import { siwnClient } from "./client.js";
 import { SUB_ACCOUNT_LABEL_REGEX } from "./types.js";
-import { hex } from "@scure/base";
+import { hex, base58, base64 } from "@scure/base";
 import { atom } from "nanostores";
+import { ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
 
 const MOCK_ACCOUNT_ID = "test.near";
 const MOCK_TESTNET_ACCOUNT_ID = "test.testnet";
@@ -1207,6 +1208,130 @@ describe("siwnClient getActions", () => {
 				publicKey: "ed25519:bob",
 				networkId: "mainnet",
 			});
+		});
+	});
+
+	describe("ml-dsa-65 signatures", () => {
+		const MLDSA65_PUBLIC_KEY_LENGTH = 1952;
+
+		function concat(parts: Uint8Array[]): Uint8Array {
+			const total = parts.reduce((sum, p) => sum + p.length, 0);
+			const out = new Uint8Array(total);
+			let offset = 0;
+			for (const p of parts) {
+				out.set(p, offset);
+				offset += p.length;
+			}
+			return out;
+		}
+
+		function borshU32(value: number, littleEndian = true): Uint8Array {
+			const out = new Uint8Array(4);
+			new DataView(out.buffer).setUint32(0, value, littleEndian);
+			return out;
+		}
+
+		function borshString(value: string): Uint8Array {
+			const bytes = new TextEncoder().encode(value);
+			return concat([borshU32(bytes.length), bytes]);
+		}
+
+		async function makeMlDsa65VerifyBody(accountId: string = MOCK_ACCOUNT_ID, tamperSignature = false) {
+			const seed = new Uint8Array(32).fill(7);
+			const keys = ml_dsa65.keygen(seed);
+			const publicKey = `ml-dsa-65:${base58.encode(keys.publicKey)}`;
+
+			const nonce = new Uint8Array(32);
+			new DataView(nonce.buffer).setBigUint64(0, BigInt(Date.now()), false);
+			crypto.getRandomValues(nonce.subarray(8));
+
+			const message = `Sign in to ${MOCK_RECIPIENT}`;
+			const recipient = MOCK_RECIPIENT;
+			const tagBytes = borshU32(2147484061, true);
+			const callbackNone = borshU32(0, true);
+			const payload = concat([tagBytes, borshString(message), nonce, borshString(recipient), callbackNone]);
+			const payloadAb = (() => {
+				const ab = new ArrayBuffer(payload.byteLength);
+				new Uint8Array(ab).set(payload);
+				return ab;
+			})();
+			const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", payloadAb));
+			const signatureBytes = ml_dsa65.sign(hash, keys.secretKey);
+			const signature = base64.encode(tamperSignature ? flipBytes(signatureBytes) : signatureBytes);
+
+			return {
+				signedMessage: { accountId, publicKey, signature },
+				message,
+				recipient,
+				nonce: hex.encode(nonce),
+				accountId,
+			};
+		}
+
+		function flipBytes(bytes: Uint8Array): Uint8Array {
+			const out = new Uint8Array(bytes);
+			out[0] ^= 0xff;
+			return out;
+		}
+
+		it("should accept a valid ml-dsa-65 signed message and create a session", async () => {
+			const { verifyNep413Signature } = await import("near-kit");
+			(verifyNep413Signature as any).mockClear();
+			(verifyNep413Signature as any).mockImplementation(() => {
+				throw new Error("Only Ed25519 keys are supported for NEP-413");
+			});
+
+			const { client } = await setup();
+			const body = await makeMlDsa65VerifyBody();
+			expect(body.signedMessage.publicKey.startsWith("ml-dsa-65:")).toBe(true);
+			const decoded = base58.decode(body.signedMessage.publicKey.slice("ml-dsa-65:".length));
+			expect(decoded.length).toBe(MLDSA65_PUBLIC_KEY_LENGTH);
+
+			const { data, error } = await client.near.verify(body);
+			expect(verifyNep413Signature as any).not.toHaveBeenCalled();
+			expect(error).toBeNull();
+			expect(data?.success).toBe(true);
+			expect(data?.token).toBeDefined();
+			expect(data?.user.accountId).toBe(MOCK_ACCOUNT_ID);
+		});
+
+		it("should reject an ml-dsa-65 message with a tampered signature", async () => {
+			const { client } = await setup();
+			const body = await makeMlDsa65VerifyBody(undefined, true);
+			const { error } = await client.near.verify(body);
+			expect(error).toBeDefined();
+		});
+
+		it("should accept an ml-dsa-65 signed message on the link-account endpoint", async () => {
+			const { verifyNep413Signature } = await import("near-kit");
+			(verifyNep413Signature as any).mockClear();
+			(verifyNep413Signature as any).mockImplementation(() => {
+				throw new Error("Only Ed25519 keys are supported for NEP-413");
+			});
+
+			const { customFetchImpl, signInWithTestUser } = await getTestInstance(
+				{
+					plugins: [siwn({ recipient: MOCK_RECIPIENT, requireFullAccessKey: false })],
+					emailAndPassword: { enabled: true },
+				},
+				{ clientOptions: { plugins: [] } },
+			);
+
+			const { headers } = await signInWithTestUser();
+			const body = await makeMlDsa65VerifyBody();
+
+			const res = await customFetchImpl("http://localhost/api/auth/near/link-account", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					cookie: headers.get("cookie") || "",
+				},
+				body: JSON.stringify(body),
+			});
+			expect(res.status).toBe(200);
+			expect(verifyNep413Signature as any).not.toHaveBeenCalled();
+			const json = await res.json();
+			expect(json.success).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
Fixes [NEARBuilders/nearbuilders.org#220](https://github.com/NEARBuilders/nearbuilders.org/issues/220).

## Summary

Wallets holding post-quantum `ml-dsa-65:` (FIPS 204) full-access keys were being rejected by `/api/auth/near/verify` and `/api/auth/near/link-account` with `401 Unauthorized: Invalid signature`. Root cause: `near-kit`'s `verifyNep413Signature` hardcodes an Ed25519-only check, even in the latest version. So ML-DSA-65 NEP-413 verification has to be done in this plugin itself.

## Changes

- **`.changeset/support-ml-dsa-65-signatures.md`** — patch-level changeset describing the fix.
- **`package.json`** — bump `near-kit ^0.14.0 → ^0.19.0`; add `@noble/post-quantum ^0.6.1` for `ml_dsa65.verify`.
- **`src/index.ts`** — new `verifyMlDsa65Nep413Signature` helper (same NEP-413 SHA-256 + borsh payload format + timestamp-based maxAge check as the ed25519 path, but signs through `@noble/post-quantum`. Still hits `near.getAccessKey` for the full-access check). Both `/near/verify` and `/near/link-account` now branch on `signedMessage.publicKey.startsWith("ml-dsa-65:")`.
- **`src/near.test.ts`** — three new tests using a real FIPS-204 round-trip:
  1. Valid ML-DSA-65 verify → 200
  2. Tampered ML-DSA-65 signature → 401
  3. Valid ML-DSA-65 on `/near/link-account` → 200
- **`scripts/sync-example-version.mjs`** — extended to also copy the parent lib's `near-kit` range into the `auth.everything.dev` pnpm catalog, so future bumps don't drift.
- **`examples/auth.everything.dev/package.json`** — `near-kit: ^0.14.0 → ^0.19.0` in the catalog (matches the bumped dep).
- **`README.md`** — new `### Post-Quantum Keys` section under Security.

## Verification

- `pnpm typecheck` — clean.
- `pnpm test` — 80 / 80 (3 new ML-DSA-65 tests included).
- Issue payload (`eightenthusiast.tg` with `ml-dsa-65:` 1952-byte pubkey, base64 3309-byte signature) now verifies instead of bouncing.

## Notes

- Scope is intentionally narrow: only `ml-dsa-65:`. Other post-quantum schemes would be additive similarly if the wallet ecosystem grows that way.
- The post-quantum branch keeps the same access-key defense-in-depth as ed25519, so the key still must be a real on-chain full-access key attached to the claimed account.
- Sub-account creation / delegate-action relay paths are unchanged.