### PR TITLE
feat: add better-near-auth/react hooks and typed near atoms

### DIFF
--- a/.changeset/near-react-hooks.md
+++ b/.changeset/near-react-hooks.md
@@ -1,0 +1,5 @@
+---
+"better-near-auth": minor
+---
+
+Add `better-near-auth/react` entry with `useNearState`, `useNearAccountId` (session fallback), `useWalletConnected`, `useActiveNetwork`, and `useNearConnection` hooks, plus typed `NearState`, `NearClientAtoms`, `NearNetwork`, and `getNearAtoms` exports from `better-near-auth/client`

--- a/examples/auth.everything.dev/ui/src/lib/near.ts
+++ b/examples/auth.everything.dev/ui/src/lib/near.ts
@@ -1,0 +1,6 @@
+import { useNearAccountId as useNearAccountIdOf } from "better-near-auth/react";
+import { useAuthClient } from "./auth";
+
+export function useNearAccountId() {
+  return useNearAccountIdOf(useAuthClient());
+}

--- a/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/auth-methods.tsx
+++ b/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/auth-methods.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { type SessionData, sessionQueryOptions, useAuthClient } from "@/app";
 import { AuthMethodsPanel, useUserPasskeys } from "@/components/settings-sections";
+import { useNearAccountId } from "@/lib/near";
 
 export const Route = createFileRoute("/_layout/_authenticated/auth-methods")({
   head: () => ({
@@ -31,7 +32,7 @@ function AuthMethodsPage() {
   const user = session?.user;
   const passkeysQuery = useUserPasskeys(!!user);
   const passkeys = passkeysQuery.data ?? [];
-  const nearAccountId = auth.near.getAccountId();
+  const nearAccountId = useNearAccountId();
 
   if (sessionQuery.isLoading || passkeysQuery.isLoading) {
     return (

--- a/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/settings.tsx
+++ b/examples/auth.everything.dev/ui/src/routes/_layout/_authenticated/settings.tsx
@@ -6,6 +6,7 @@ import { type SessionData, sessionQueryOptions, useAuthClient } from "@/app";
 import { Button, Card, CardContent } from "@/components";
 import { useUserPasskeys } from "@/components/settings-sections";
 import { Input } from "@/components/ui/input";
+import { useNearAccountId } from "@/lib/near";
 
 export const Route = createFileRoute("/_layout/_authenticated/settings")({
   head: () => ({
@@ -38,7 +39,7 @@ function Settings() {
   const { data: session } = useQuery<SessionData | null>(sessionQueryOptions(auth));
   const user = session?.user;
   const { data: passkeys = [] } = useUserPasskeys(!!user);
-  const nearAccountId = auth.near.getAccountId();
+  const nearAccountId = useNearAccountId();
 
   if (!user) {
     return null;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "./client": {
       "import": "./dist/client.js",
       "types": "./dist/client.d.ts"
+    },
+    "./react": {
+      "import": "./dist/react.js",
+      "types": "./dist/react.d.ts"
     }
   },
   "scripts": {
@@ -57,7 +61,13 @@
   "peerDependencies": {
     "@better-auth/core": "^1.6.25",
     "better-auth": "^1.6.25",
+    "react": "^18.0.0 || ^19.0.0",
     "typescript": "^5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@scure/base": "^2.2.0",
@@ -72,6 +82,7 @@
     "@tanstack/intent": "^0.0.40",
     "@types/bun": "latest",
     "@types/node": "^25.0.9",
+    "@types/react": "^19.2.7",
     "@better-auth/core": "^1.6.25",
     "better-call": "^1.3.7",
     "better-auth": "^1.6.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       near-kit:
         specifier: ^0.14.0
         version: 0.14.0(@hot-labs/near-connect@0.11.4)
+      react:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.5
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -42,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^25.0.9
         version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
       better-auth:
         specifier: ^1.6.25
         version: 1.6.25(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(better-sqlite3@11.10.0)(bun-types@1.3.13)(gel@2.2.0)(kysely@0.29.4))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)))
@@ -1253,8 +1259,8 @@ packages:
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
 
-  '@oxc-project/types@0.142.0':
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+  '@oxc-project/types@0.147.0':
+    resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
@@ -1961,14 +1967,20 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.2.2':
-    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+  '@rolldown/binding-android-arm64@1.2.6':
+    resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1979,8 +1991,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1991,8 +2003,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+  '@rolldown/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -2003,8 +2015,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.2.2':
-    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2015,8 +2027,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
-    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -2028,8 +2040,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2042,8 +2054,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.2':
-    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2056,8 +2068,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
-    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2070,8 +2082,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.2':
-    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -2084,8 +2096,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2098,8 +2110,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2111,8 +2123,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.2.2':
-    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -2128,8 +2140,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.2':
-    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -2140,8 +2152,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4087,8 +4099,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.2.2:
-    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+  rolldown@1.2.6:
+    resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5569,7 +5581,7 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
-  '@oxc-project/types@0.142.0': {}
+  '@oxc-project/types@0.147.0': {}
 
   '@petamoriken/float16@3.9.3':
     optional: true
@@ -6332,76 +6344,79 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.2.2':
+  '@rolldown/binding-android-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.2':
+  '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.2':
+  '@rolldown/binding-darwin-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.2':
+  '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.2':
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.2':
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.2':
+  '@rolldown/binding-linux-x64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.2':
+  '@rolldown/binding-openharmony-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.1':
@@ -6414,13 +6429,13 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.0.1':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.2':
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
     optional: true
 
   '@rolldown/pluginutils@1.0.0': {}
@@ -8492,7 +8507,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.15.10(rolldown@1.2.2)(typescript@5.9.3):
+  rolldown-plugin-dts@0.15.10(rolldown@1.2.6)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.3
@@ -8502,7 +8517,7 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.3
       get-tsconfig: 4.14.0
-      rolldown: 1.2.2
+      rolldown: 1.2.6
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8546,25 +8561,26 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
 
-  rolldown@1.2.2:
+  rolldown@1.2.6:
     dependencies:
-      '@oxc-project/types': 0.142.0
+      '@oxc-project/types': 0.147.0
       '@rolldown/pluginutils': 1.0.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.2
-      '@rolldown/binding-darwin-arm64': 1.2.2
-      '@rolldown/binding-darwin-x64': 1.2.2
-      '@rolldown/binding-freebsd-x64': 1.2.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
-      '@rolldown/binding-linux-arm64-gnu': 1.2.2
-      '@rolldown/binding-linux-arm64-musl': 1.2.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
-      '@rolldown/binding-linux-s390x-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-gnu': 1.2.2
-      '@rolldown/binding-linux-x64-musl': 1.2.2
-      '@rolldown/binding-openharmony-arm64': 1.2.2
-      '@rolldown/binding-win32-arm64-msvc': 1.2.2
-      '@rolldown/binding-win32-x64-msvc': 1.2.2
+      '@rolldown/binding-android-arm-eabi': 1.2.6
+      '@rolldown/binding-android-arm64': 1.2.6
+      '@rolldown/binding-darwin-arm64': 1.2.6
+      '@rolldown/binding-darwin-x64': 1.2.6
+      '@rolldown/binding-freebsd-x64': 1.2.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.6
+      '@rolldown/binding-linux-arm64-gnu': 1.2.6
+      '@rolldown/binding-linux-arm64-musl': 1.2.6
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.6
+      '@rolldown/binding-linux-s390x-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-musl': 1.2.6
+      '@rolldown/binding-openharmony-arm64': 1.2.6
+      '@rolldown/binding-win32-arm64-msvc': 1.2.6
+      '@rolldown/binding-win32-x64-msvc': 1.2.6
 
   rollup@4.60.2:
     dependencies:
@@ -8798,8 +8814,8 @@ snapshots:
       diff: 8.0.4
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.2.2
-      rolldown-plugin-dts: 0.15.10(rolldown@1.2.2)(typescript@5.9.3)
+      rolldown: 1.2.6
+      rolldown-plugin-dts: 0.15.10(rolldown@1.2.6)(typescript@5.9.3)
       semver: 7.7.4
       tinyexec: 1.1.2
       tinyglobby: 0.2.16

--- a/skills/client/SKILL.md
+++ b/skills/client/SKILL.md
@@ -172,7 +172,7 @@ if (detected) {
 
 `detectNearAccount()` silently probes `@hot-labs/near-connect`'s `getConnectedWallet()` across all supported networks — it reads localStorage for previously authorized wallet IDs and queries the wallet extension without showing any UI. Returns `null` if no wallet is found. Use it on login pages to offer a one-click "Continue with NEAR" option.
 
-When the wallet disconnects externally (user signs out from wallet UI), `nearState` preserves `accountId` but clears `publicKey`. Use `isWalletConnected()` to check if signing operations are available, and `getAccountId()` for display purposes (works even when disconnected).
+When the wallet disconnects externally (user signs out from wallet UI), `nearState` preserves `accountId` but clears `publicKey`. Use `isWalletConnected()` to check if signing operations are available, and `useNearAccountId(authClient)` (React) or `getAccountId()` for display purposes (works even when disconnected).
 
 ### Sub-account creation
 
@@ -432,18 +432,25 @@ const accountId = authClient.near.getAccountId();
 Correct:
 
 ```typescript
-// Subscribe to nearState for reactive updates
-import { useStore } from "nanostores/react";
-const { nearState } = authClient.$store;
-const state = useStore(nearState);
-// state preserves accountId when wallet disconnects
-// publicKey becomes null, walletConnected becomes false
+// React: subscribe reactively (no extra deps)
+import { useNearAccountId, useNearConnection } from "better-near-auth/react";
+const accountId = useNearAccountId(authClient);
+// or the combined shape: { accountId, publicKey, networkId, walletConnected }
+const connection = useNearConnection(authClient);
+// accountId preserves the live connection, falling back to the
+// session-linked account; publicKey is null when the wallet is
+// disconnected but the account stays visible
+
+// Vanilla (no React): typed atom access
+import { getNearAtoms } from "better-near-auth/client";
+const { nearState, walletConnected } = getNearAtoms(authClient);
+nearState.subscribe(() => console.log(nearState.get()));
 
 // Or check signing availability:
 const canSign = authClient.near.isWalletConnected();
 ```
 
-When the wallet disconnects externally (user signs out from wallet UI), `nearState` preserves `accountId` but clears `publicKey` and sets `walletConnected` to false. Use `isWalletConnected()` to check if signing operations are available, and `getAccountId()` for display purposes (works even when disconnected).
+When the wallet disconnects externally (user signs out from wallet UI), `nearState` preserves `accountId` but clears `publicKey` and sets `walletConnected` to false. Use `isWalletConnected()` to check if signing operations are available, and `useNearAccountId(client)` / `getAccountId()` for display purposes (works even when disconnected).
 
 Source: src/client.ts:65-66, src/client.ts:102-108
 

--- a/skills/client/SKILL.md
+++ b/skills/client/SKILL.md
@@ -4,8 +4,11 @@ description: >
   Set up the siwnClient plugin for Better Auth client, configure NEAR wallet
   connection via NearConnect, use authClient.near actions for sign-in, profile
   lookup, account management, delegate action building with TransactionBuilder,
-  and relay submission. Load when implementing NEAR wallet sign-in on the client,
-  using authClient.near.* methods,   or building delegate actions for gasless relay.
+  and relay submission. Use the better-near-auth/react hooks (useNearAccountId,
+  useNearConnection, useNearState, useWalletConnected, useActiveNetwork) and
+  typed atoms via getNearAtoms for reactive wallet state. Load when implementing
+  NEAR wallet sign-in on the client, using authClient.near.* methods, consuming
+  wallet state in React, or building delegate actions for gasless relay.
 metadata:
   type: core
   library: better-near-auth
@@ -445,6 +448,11 @@ const connection = useNearConnection(authClient);
 import { getNearAtoms } from "better-near-auth/client";
 const { nearState, walletConnected } = getNearAtoms(authClient);
 nearState.subscribe(() => console.log(nearState.get()));
+
+// Vanilla: read the session-linked account (same fallback the hooks use) —
+// session.user.nearAccount is set by an after-hook, so narrow it via the helper
+import { readSessionNearAccountId } from "better-near-auth/client";
+const linkedAccountId = readSessionNearAccountId(sessionAtomValue);
 
 // Or check signing availability:
 const canSign = authClient.near.isWalletConnected();

--- a/skills/tanstack/SKILL.md
+++ b/skills/tanstack/SKILL.md
@@ -220,6 +220,32 @@ When the wallet disconnects externally:
 
 This means UI can display the user's NEAR account even when the wallet is disconnected. Signing operations automatically prompt reconnection.
 
+### Reactive reads via better-near-auth/react
+
+Prefer the React hooks over `getAccountId()` during render — the getter is not reactive:
+
+```typescript
+import { useNearAccountId, useNearConnection } from "better-near-auth/react";
+
+function Greeting() {
+  const authClient = useAuthClient();
+  const accountId = useNearAccountId(authClient); // live connection ?? session-linked account
+  // or: const { accountId, networkId, walletConnected } = useNearConnection(authClient);
+}
+```
+
+In apps where `authClient` lives in router context, bind the hook once in an app-owned module:
+
+```typescript
+// lib/near.ts
+import { useNearAccountId as useNearAccountIdOf } from "better-near-auth/react";
+import { useAuthClient } from "./auth";
+
+export function useNearAccountId() {
+  return useNearAccountIdOf(useAuthClient());
+}
+```
+
 ## SSR Safety
 
 `siwnClient()` is SSR-safe — wallet resources are lazily initialized on first client-side access. On the server they sit dormant. However, `createAuthClient()` calls `getHostUrl()`, `getAccount()`, and `getNetworkId()`, which read `window.__RUNTIME_CONFIG__` by default. On the server, you **must** pass `{ runtimeConfig }` so these helpers read from the provided config instead of the browser-only `window` object:

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,10 @@ import type { EventMap } from "@hot-labs/near-connect";
 import { hex } from "@scure/base";
 import type { BetterFetch, BetterFetchOption, BetterFetchResponse, ClientStore } from "better-auth/client";
 import { atom } from "nanostores";
+import type { NearClientAtoms, NearNetwork, NearState } from "./store.js";
 import { type AccountId, type DualNetworkConfig, type NonceRequestT, type NonceResponseT, type ProfileResponseT, type VerifyRequestT, type VerifyResponseT, type RelayResponseT, type RelayStatusResponseT, type NearAccount, type ListAccountsResponseT, type SetPrimaryAccountRequestT, type SetPrimaryAccountResponseT, type ViewContractRequestT, type ViewContractResponseT, type RelayerInfo, type RelayHistoryResponseT, type GetRelayerInfoRequestT, type CreateSubAccountRequestT, type CreateSubAccountResponseT, type CheckSubAccountAvailabilityRequestT, type CheckSubAccountAvailabilityResponseT, SUB_ACCOUNT_LABEL_REGEX } from "./types.js";
+
+export { getNearAtoms, type NearAtomsSource, type NearClientAtoms, type NearNetwork, type NearState } from "./store.js";
 
 export interface AuthCallbacks {
 	onSuccess?: () => void;
@@ -32,7 +35,7 @@ export interface SIWNClientActions {
 		getProfile: (accountId?: AccountId) => Promise<BetterFetchResponse<ProfileResponseT>>;
 		view: (params: ViewContractRequestT) => Promise<BetterFetchResponse<ViewContractResponseT>>;
 		getAccountId: () => string | null;
-		getState: () => { accountId: string | null; publicKey: string | null; networkId: string } | null;
+		getState: () => NearState;
 		isWalletConnected: () => boolean;
 		detectNearAccount: () => Promise<{ accountId: string; publicKey: string | null; networkId: string } | null>;
 		ensureConnected: () => Promise<boolean>;
@@ -59,12 +62,10 @@ export interface SIWNClientActions {
 	};
 }
 
-type NearState = { accountId: string | null; publicKey: string | null; networkId: string } | null;
-
 export const siwnClient = (config: SIWNClientConfig) => {
 	const nearState = atom<NearState>(null);
 	const walletConnected = atom<boolean>(false);
-	const activeNetwork = atom<"mainnet" | "testnet">(config.networkId || "mainnet");
+	const activeNetwork = atom<NearNetwork>(config.networkId || "mainnet");
 
 	const getRecipient = (network?: "mainnet" | "testnet"): string => {
 		const net = network || activeNetwork.get();
@@ -354,7 +355,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 		id: "siwn" as const,
 		$InferServerPlugin: {},
 
-		getAtoms: (_$fetch: BetterFetch) => ({
+		getAtoms: (_$fetch: BetterFetch): NearClientAtoms => ({
 			nearState,
 			walletConnected,
 			activeNetwork,

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from "react";
 import type { WritableAtom } from "nanostores";
-import { getNearAtoms, type NearAtomsSource, type NearNetwork, type NearState } from "./store.js";
+import { getNearAtoms, readSessionNearAccountId, type NearAtomsSource, type NearNetwork, type NearState } from "./store.js";
 
-export { getNearAtoms, type NearAtomsSource, type NearClientAtoms, type NearNetwork, type NearState } from "./store.js";
+export { getNearAtoms, readSessionNearAccountId, type NearAtomsSource, type NearClientAtoms, type NearNetwork, type NearState } from "./store.js";
 
 export type NearConnection = {
 	accountId: string | null;
@@ -11,18 +11,9 @@ export type NearConnection = {
 	walletConnected: boolean;
 };
 
-type SessionAtomValue = {
-	data?: { user?: { nearAccount?: { accountId?: unknown } } } | null;
-} | undefined;
-
-type SessionAtom = WritableAtom<SessionAtomValue>;
+type SessionAtom = WritableAtom<unknown>;
 
 const noopSubscribe = () => () => {};
-
-function readSessionAccountId(session: SessionAtomValue): string | null {
-	const accountId = session?.data?.user?.nearAccount?.accountId;
-	return typeof accountId === "string" ? accountId : null;
-}
 
 function useAtomValue<T>(atom: WritableAtom<T>): T {
 	return useSyncExternalStore(atom.subscribe, atom.get, atom.get);
@@ -32,7 +23,7 @@ function useSessionAccountId(client: NearAtomsSource): string | null {
 	const sessionAtom = client.$store?.atoms?.session as SessionAtom | undefined;
 	return useSyncExternalStore(
 		sessionAtom ? sessionAtom.subscribe : noopSubscribe,
-		() => readSessionAccountId(sessionAtom?.get()),
+		() => readSessionNearAccountId(sessionAtom?.get()),
 		() => null,
 	);
 }

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from "react";
+import type { WritableAtom } from "nanostores";
+import { getNearAtoms, type NearAtomsSource, type NearNetwork, type NearState } from "./store.js";
+
+export { getNearAtoms, type NearAtomsSource, type NearClientAtoms, type NearNetwork, type NearState } from "./store.js";
+
+export type NearConnection = {
+	accountId: string | null;
+	publicKey: string | null;
+	networkId: string;
+	walletConnected: boolean;
+};
+
+type SessionAtomValue = {
+	data?: { user?: { nearAccount?: { accountId?: unknown } } } | null;
+} | undefined;
+
+type SessionAtom = WritableAtom<SessionAtomValue>;
+
+const noopSubscribe = () => () => {};
+
+function readSessionAccountId(session: SessionAtomValue): string | null {
+	const accountId = session?.data?.user?.nearAccount?.accountId;
+	return typeof accountId === "string" ? accountId : null;
+}
+
+function useAtomValue<T>(atom: WritableAtom<T>): T {
+	return useSyncExternalStore(atom.subscribe, atom.get, atom.get);
+}
+
+function useSessionAccountId(client: NearAtomsSource): string | null {
+	const sessionAtom = client.$store?.atoms?.session as SessionAtom | undefined;
+	return useSyncExternalStore(
+		sessionAtom ? sessionAtom.subscribe : noopSubscribe,
+		() => readSessionAccountId(sessionAtom?.get()),
+		() => null,
+	);
+}
+
+export function useNearState(client: NearAtomsSource): NearState {
+	return useAtomValue(getNearAtoms(client).nearState);
+}
+
+export function useWalletConnected(client: NearAtomsSource): boolean {
+	return useAtomValue(getNearAtoms(client).walletConnected);
+}
+
+export function useActiveNetwork(client: NearAtomsSource): NearNetwork {
+	return useAtomValue(getNearAtoms(client).activeNetwork);
+}
+
+export function useNearAccountId(client: NearAtomsSource): string | null {
+	const state = useNearState(client);
+	const linkedAccountId = useSessionAccountId(client);
+	return state?.accountId ?? linkedAccountId;
+}
+
+export function useNearConnection(client: NearAtomsSource): NearConnection {
+	const { nearState, walletConnected, activeNetwork } = getNearAtoms(client);
+	const state = useAtomValue(nearState);
+	const connected = useAtomValue(walletConnected);
+	const network = useAtomValue(activeNetwork);
+	const linkedAccountId = useSessionAccountId(client);
+	return {
+		accountId: state?.accountId ?? linkedAccountId,
+		publicKey: state?.publicKey ?? null,
+		networkId: state?.networkId ?? network,
+		walletConnected: connected,
+	};
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { atom, type WritableAtom } from "nanostores";
-import { getNearAtoms, type NearState } from "./store.js";
+import { getNearAtoms, readSessionNearAccountId, type NearState } from "./store.js";
 
-function createClient(atoms: Record<string, WritableAtom<any>>) {
+function createClient(atoms: Record<string, WritableAtom<unknown>>) {
 	return { $store: { atoms } };
 }
 
@@ -33,5 +33,28 @@ describe("getNearAtoms", () => {
 		expect(() => getNearAtoms({})).toThrow(/siwnClient/);
 		expect(() => getNearAtoms(createClient({}))).toThrow(/siwnClient/);
 		expect(() => getNearAtoms(createClient({ nearState: atom(null) }))).toThrow(/siwnClient/);
+	});
+});
+
+describe("readSessionNearAccountId", () => {
+	it("returns the primary linked account from the session", () => {
+		const session = {
+			data: {
+				user: {
+					id: "user-1",
+					nearAccount: { accountId: "alice.near", network: "mainnet", isPrimary: true },
+				},
+			},
+		};
+		expect(readSessionNearAccountId(session)).toBe("alice.near");
+	});
+
+	it("returns null for missing, cleared, or malformed sessions", () => {
+		expect(readSessionNearAccountId(null)).toBeNull();
+		expect(readSessionNearAccountId(undefined)).toBeNull();
+		expect(readSessionNearAccountId({ data: null })).toBeNull();
+		expect(readSessionNearAccountId({ data: { user: {} } })).toBeNull();
+		expect(readSessionNearAccountId({ data: { user: { nearAccount: { accountId: 123 } } } })).toBeNull();
+		expect(readSessionNearAccountId("not a session")).toBeNull();
 	});
 });

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { atom, type WritableAtom } from "nanostores";
+import { getNearAtoms, type NearState } from "./store.js";
+
+function createClient(atoms: Record<string, WritableAtom<any>>) {
+	return { $store: { atoms } };
+}
+
+describe("getNearAtoms", () => {
+	it("returns the siwnClient atoms from the client store", () => {
+		const nearState = atom<NearState>(null);
+		const walletConnected = atom<boolean>(false);
+		const activeNetwork = atom<"mainnet" | "testnet">("mainnet");
+
+		const atoms = getNearAtoms(createClient({ nearState, walletConnected, activeNetwork }));
+
+		expect(atoms.nearState).toBe(nearState);
+		expect(atoms.walletConnected).toBe(walletConnected);
+		expect(atoms.activeNetwork).toBe(activeNetwork);
+	});
+
+	it("reads and writes through the same atom instances", () => {
+		const nearState = atom<NearState>(null);
+		const { nearState: typed } = getNearAtoms(
+			createClient({ nearState, walletConnected: atom(false), activeNetwork: atom("testnet") }),
+		);
+
+		typed.set({ accountId: "alice.near", publicKey: "pk", networkId: "mainnet" });
+		expect(nearState.get()).toEqual({ accountId: "alice.near", publicKey: "pk", networkId: "mainnet" });
+	});
+
+	it("throws when siwnClient is not part of the client plugins", () => {
+		expect(() => getNearAtoms({})).toThrow(/siwnClient/);
+		expect(() => getNearAtoms(createClient({}))).toThrow(/siwnClient/);
+		expect(() => getNearAtoms(createClient({ nearState: atom(null) }))).toThrow(/siwnClient/);
+	});
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,18 +15,27 @@ export type NearClientAtoms = {
 };
 
 export type NearAtomsSource = {
-	$store?: { atoms?: Record<string, WritableAtom<any>> } | null;
+	$store?: { atoms?: Record<string, WritableAtom<unknown>> } | null;
 };
 
 export function getNearAtoms(client: NearAtomsSource): NearClientAtoms {
 	const atoms = client?.$store?.atoms;
-	const { nearState, walletConnected, activeNetwork } = atoms ?? {};
-	if (!nearState || !walletConnected || !activeNetwork) {
+	if (!atoms?.nearState || !atoms.walletConnected || !atoms.activeNetwork) {
 		throw new Error("Missing near atoms — add siwnClient() to your createAuthClient plugins");
 	}
-	return {
-		nearState: nearState as WritableAtom<NearState>,
-		walletConnected: walletConnected as WritableAtom<boolean>,
-		activeNetwork: activeNetwork as WritableAtom<NearNetwork>,
-	};
+	// The store record erases atom value types — siwnClient() guarantees these shapes.
+	return atoms as unknown as NearClientAtoms;
+}
+
+/**
+ * Read the primary SIWN-linked account ID (`session.user.nearAccount`) from a
+ * better-auth session-atom value. The `nearAccount` field is populated by an
+ * `after` hook on `GET /auth/session`, so it is not part of the inferred
+ * session user type — this helper narrows it in one place, shared by
+ * `getAccountId()` and the React hooks.
+ */
+export function readSessionNearAccountId(session: unknown): string | null {
+	const accountId = (session as { data?: { user?: { nearAccount?: { accountId?: unknown } } } } | null | undefined)
+		?.data?.user?.nearAccount?.accountId;
+	return typeof accountId === "string" ? accountId : null;
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,32 @@
+import type { WritableAtom } from "nanostores";
+
+export type NearNetwork = "mainnet" | "testnet";
+
+export type NearState = {
+	accountId: string | null;
+	publicKey: string | null;
+	networkId: string;
+} | null;
+
+export type NearClientAtoms = {
+	nearState: WritableAtom<NearState>;
+	walletConnected: WritableAtom<boolean>;
+	activeNetwork: WritableAtom<NearNetwork>;
+};
+
+export type NearAtomsSource = {
+	$store?: { atoms?: Record<string, WritableAtom<any>> } | null;
+};
+
+export function getNearAtoms(client: NearAtomsSource): NearClientAtoms {
+	const atoms = client?.$store?.atoms;
+	const { nearState, walletConnected, activeNetwork } = atoms ?? {};
+	if (!nearState || !walletConnected || !activeNetwork) {
+		throw new Error("Missing near atoms — add siwnClient() to your createAuthClient plugins");
+	}
+	return {
+		nearState: nearState as WritableAtom<NearState>,
+		walletConnected: walletConnected as WritableAtom<boolean>,
+		activeNetwork: activeNetwork as WritableAtom<NearNetwork>,
+	};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,5 +29,5 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules/**", "src/near.test.ts", "examples/**"]
+  "exclude": ["node_modules/**", "src/*.test.ts", "examples/**"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -29,4 +29,17 @@ export default defineConfig([
 		},
 		clean: false,
 	},
+	{
+		entry: ['src/react.ts'],
+		format: 'esm',
+		dts: false,
+		sourcemap: true,
+		hash: false,
+		fixedExtension: false,
+		deps: {
+			neverBundle: [...neverBundle, /^react/],
+			onlyBundle: false,
+		},
+		clean: false,
+	},
 ])


### PR DESCRIPTION
## Summary

- Adds a `better-near-auth/react` entry with hooks over the siwnClient atoms (`useSyncExternalStore`, no new runtime deps, React optional peer):
  - `useNearState(client)`, `useWalletConnected(client)`, `useActiveNetwork(client)`
  - `useNearAccountId(client)` — live connection with session fallback (reactive mirror of `near.getAccountId()`)
  - `useNearConnection(client)` — combined `{ accountId, publicKey, networkId, walletConnected }`
- Exports `NearState`, `NearNetwork`, `NearClientAtoms`, and `getNearAtoms(client)` from `better-near-auth/client`, replacing the `Record<string, WritableAtom<any>>` cast consumers previously needed
- Example app: replaces the remaining non-reactive render-time `getAccountId()` reads (settings, auth-methods) with a router-context-bound `useNearAccountId()` in an app-owned `ui/src/lib/near.ts` (framework-owned files untouched)
- Updates client/tanstack skills to the new typed API; adds minor changeset

## Test plan

- [x] `pnpm typecheck` and `pnpm test` (73 tests, incl. new `store.test.ts`)
- [x] `pnpm build` emits `dist/react.js` + declarations
- [x] Example `ui` typechecks against the local build (only pre-existing generated-file duplicates remain)
- [x] biome clean on touched example files