### PR TITLE
fix: apply NEP-413 key policy uniformly to ed25519 and ml-dsa-65 signatures

### DIFF
--- a/.changeset/nep413-key-policy.md
+++ b/.changeset/nep413-key-policy.md
@@ -1,0 +1,9 @@
+---
+"better-near-auth": patch
+---
+
+fix: NEP-413 key policy now governs both ed25519 and ml-dsa-65 signatures
+
+The SIWN endpoints (`/api/auth/near/verify` and `/api/auth/near/link-account`) delegated the on-chain access-key check to `near-kit`'s `verifyNep413Signature`, which hard-requires a FullAccess key before the plugin's own `requireFullAccessKey` / `validateLimitedAccessKey` policy ever runs. That made the documented default (`requireFullAccessKey: false` — full-access key or function-call key scoped to the recipient) unreachable: function-call keys were rejected with `401 Invalid signature`, and custom validators could restrict but never enable limited keys.
+
+Signature verification and key policy are now separated. Both endpoints verify the NEP-413 signature (ed25519 via near-kit, ml-dsa-65 via `@noble/post-quantum`) and then enforce the plugin's key policy uniformly: the signing key must exist on the claimed account (the defense-in-depth `getAccessKey` check is preserved, now once per request in the policy step instead of inside each signature verifier), and then `requireFullAccessKey` / `validateLimitedAccessKey` decide which key permissions are accepted. Function-call access keys scoped to the recipient are accepted by default, matching the documented behavior, and the ml-dsa-65 path now honors the same policy as ed25519. Also dedupes the identical verify/link-account signature-dispatch and key-policy blocks into shared helpers.

--- a/LLM.txt
+++ b/LLM.txt
@@ -4,7 +4,7 @@
 
 Better-near-auth is a Better Auth plugin implementing Sign in with NEAR (SIWN, NEP-413) plus a built-in NEP-366 delegate action relayer. It provides:
 
-- **SIWN authentication** — wallet-based sign-in with single-step/two-step flow
+- **SIWN authentication** — wallet-based sign-in with single-step/two-step flow; ed25519 and post-quantum `ml-dsa-65:` (FIPS 204) keys; key policy (`requireFullAccessKey` / `validateLimitedAccessKey`) applies uniformly to both key types
 - **Gasless relay** — server-side relayer broadcasts delegate actions on behalf of authenticated users, paying gas from a relayer account
 - **Ephemeral relayer keypair** — auto-generated ED25519 keypair on startup, private key encrypted with AES-256-GCM in the database, survives server restarts
 - **Rotating key store** — support for multiple relayer keys for high-throughput scenarios
@@ -51,7 +51,7 @@ Better-near-auth is a Better Auth plugin implementing Sign in with NEAR (SIWN, N
 ```typescript
 siwn({
   recipient: string;                    // NEP-413 recipient (required)
-  requireFullAccessKey?: boolean;       // default: false
+  requireFullAccessKey?: boolean;       // default: false — false accepts FAKs or FCAKs scoped to the recipient (both key types)
   getNonce?: () => Promise<Uint8Array>;
   getProfile?: (accountId: string) => Promise<Profile | null>;
   validateLimitedAccessKey?: (args: { accountId, publicKey, recipient? }) => Promise<boolean>;
@@ -178,7 +178,7 @@ authClient.near.nonce(params)
 authClient.near.verify(params)
 authClient.near.getProfile(accountId?)
 authClient.near.view({ contractId, methodName, args })
-authClient.near.getAccountId()
+authClient.near.getAccountId()   // live NearConnect connection, falling back to the primary SIWN-linked account on the session
 authClient.near.getState()
 authClient.near.disconnect()
 authClient.near.link(callbacks?)

--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ await authClient.near.disconnect();
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `recipient` | `string` | — | NEP-413 recipient identifier (required) |
-| `requireFullAccessKey` | `boolean` | `false` | Require full access keys |
+| `requireFullAccessKey` | `boolean` | `false` | Require full access keys; when false, function-call keys scoped to the recipient are accepted |
 | `getNonce` | `() => Promise<Uint8Array>` | — | Custom nonce generation |
 | `getProfile` | `(accountId: string) => Promise<Profile \| null>` | — | Custom profile lookup |
-| `validateLimitedAccessKey` | `(args) => Promise<boolean>` | — | Validate FAK when `requireFullAccessKey` is false |
+| `validateLimitedAccessKey` | `(args) => Promise<boolean>` | — | Replace the function-call key check when `requireFullAccessKey` is false (applies to both ed25519 and ml-dsa-65) |
 | `apiKey` | `string` | `process.env.FASTNEAR_API_KEY` | API key for RPC |
 | `rpcUrl` | `string` | — | Custom RPC URL (e.g., sandbox, private node) |
 | `relayer` | `RelayerConfig` | — | Relayer configuration (see below) |
@@ -430,9 +430,10 @@ The plugin detects the network from the account ID:
 - Trust model matches Better Auth session tokens: DB access + secret = full access
 
 ### Access Key Support
-- Full access keys and function-call access keys (FAK)
-- FAK scoped to recipient contract for delegate actions
+- Full access keys and function-call access keys (FCAK)
+- FCAK scoped to recipient contract for delegate actions
 - Configurable validation for limited access keys
+- The key policy (`requireFullAccessKey` / `validateLimitedAccessKey`) applies identically to ed25519 and post-quantum keys
 
 ### Post-Quantum Keys
 - `ml-dsa-65:` (FIPS 204) full-access keys are accepted on `/api/auth/near/verify` and `/api/auth/near/link-account`. Signature verification is delegated to `@noble/post-quantum`'s `ml_dsa65.verify`, while the on-chain access-key check stays the same as ed25519. The NEP-413 SHA-256 + borsh payload format is unchanged from the ed25519 path.

--- a/scripts/sync-example-version.mjs
+++ b/scripts/sync-example-version.mjs
@@ -35,6 +35,8 @@ const skillFiles = [
 	"skills/siwn/SKILL.md",
 	"skills/relay/SKILL.md",
 	"skills/tanstack/SKILL.md",
+	"skills/auth-plugin/SKILL.md",
+	"skills/subaccount/SKILL.md",
 ];
 
 for (const file of skillFiles) {

--- a/skills/siwn/SKILL.md
+++ b/skills/siwn/SKILL.md
@@ -82,9 +82,15 @@ siwn({
 });
 ```
 
-### Validate function-call access keys
+### Key policy: full-access vs function-call keys
 
-By default the plugin validates that the signing key is either a full-access key or a function-call key scoped to the recipient. Override with `validateLimitedAccessKey`:
+The signing key must exist on the claimed account (checked on-chain via `getAccessKey`) — this defense-in-depth applies to both ed25519 and ml-dsa-65 keys. Which permissions are accepted is governed by the plugin's key policy, applied uniformly to both key types:
+
+- `requireFullAccessKey: false` (default) — full-access keys **and** function-call access keys scoped to the recipient are accepted
+- `requireFullAccessKey: true` — only full-access keys are accepted; anything else returns `401 Unauthorized: Full access key required`
+- `validateLimitedAccessKey` — replaces the default function-call key check entirely. The validator may enable keys the default would reject (e.g. FCAKs scoped to another contract), but cannot skip the on-chain key-exists check
+
+Override with `validateLimitedAccessKey`:
 
 ```typescript
 siwn({
@@ -95,6 +101,10 @@ siwn({
   },
 });
 ```
+
+### Post-quantum keys (ml-dsa-65)
+
+`/near/verify` and `/near/link-account` accept `ml-dsa-65:` (FIPS 204) keys alongside ed25519. The NEP-413 payload format (SHA-256 + borsh, tag `2147484061`) is unchanged; signature verification is delegated to `@noble/post-quantum`'s `ml_dsa65.verify`, and the same key policy applies. Requires `near-kit` >= 0.19 so `getAccessKey` understands the `ml-dsa-65:` prefix on the RPC side.
 
 ### Link and unlink NEAR accounts
 
@@ -192,10 +202,10 @@ To use parent ownership, contract deployment, init calls, transaction hooks, or 
 | Option | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
 | `recipient` | `string` | — | NEP-413 recipient identifier (required) |
-| `requireFullAccessKey` | `boolean` | `false` | Require full access keys |
+| `requireFullAccessKey` | `boolean` | `false` | Require full access keys; when false, FCAKs scoped to the recipient are accepted |
 | `getNonce` | `() => Promise<Uint8Array>` | `generateNonce()` | Custom nonce generation |
 | `getProfile` | `(accountId) => Promise<Profile \| null>` | FastNear KV → NEAR Social | Custom profile lookup |
-| `validateLimitedAccessKey` | `(args) => Promise<boolean>` | Default FAK validation | Validate limited access keys |
+| `validateLimitedAccessKey` | `(args) => Promise<boolean>` | Default FCAK validation | Replace the function-call key check (applies to both ed25519 and ml-dsa-65) |
 | `apiKey` | `string` | `process.env.FASTNEAR_API_KEY` | API key for RPC |
 | `rpcUrl` | `string` | — | Custom RPC URL |
 | `relayer` | `RelayerConfig` | — | See relay skill |

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,8 +320,9 @@ async function defaultValidateLimitedAccessKey(
 	publicKey: string,
 	recipient: string,
 	near: Near,
+	accessKey?: Awaited<ReturnType<Near["getAccessKey"]>>,
 ): Promise<boolean> {
-	const key = await near.getAccessKey(accountId, publicKey);
+	const key = accessKey ?? await near.getAccessKey(accountId, publicKey);
 	if (!key) return false;
 	if (key.permission === "FullAccess") return true;
 	if ("FunctionCall" in key.permission) {
@@ -382,7 +383,6 @@ function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
 }
 
 interface MlDsa65VerifyOptions {
-	near: Near;
 	maxAge?: number;
 }
 
@@ -397,7 +397,7 @@ async function verifyMlDsa65Nep413Signature(
 	options: MlDsa65VerifyOptions,
 ): Promise<boolean> {
 	try {
-		const { near, maxAge = 5 * 60 * 1000 } = options;
+		const { maxAge = 5 * 60 * 1000 } = options;
 
 		if (!signedMessage.publicKey.startsWith(ML_DSA_65_KEY_PREFIX)) {
 			return false;
@@ -417,11 +417,6 @@ async function verifyMlDsa65Nep413Signature(
 			if (age < 0) return false;
 		}
 
-		const accessKey = await near.getAccessKey(signedMessage.accountId, signedMessage.publicKey);
-		if (!accessKey || accessKey.permission !== "FullAccess") {
-			return false;
-		}
-
 		const combined = serializeNep413Message(params);
 		const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", toArrayBuffer(combined)));
 
@@ -429,6 +424,71 @@ async function verifyMlDsa65Nep413Signature(
 		return ml_dsa65.verify(signatureBytes, hash, publicKeyBytes);
 	} catch {
 		return false;
+	}
+}
+
+const NEP413_MAX_AGE = 15 * 60 * 1000;
+
+async function verifyNep413SignatureAny(
+	signedMessage: { accountId: string; publicKey: string; signature: string },
+	params: {
+		message: string;
+		recipient: string;
+		nonce: Uint8Array;
+		callbackUrl?: string;
+	},
+): Promise<boolean> {
+	return signedMessage.publicKey.startsWith(ML_DSA_65_KEY_PREFIX)
+		? verifyMlDsa65Nep413Signature(signedMessage, params, { maxAge: NEP413_MAX_AGE })
+		: verifyNep413Signature(signedMessage, params, { maxAge: NEP413_MAX_AGE });
+}
+
+async function enforceNep413KeyPolicy(args: {
+	near: Near;
+	fallbackRecipient: string;
+	accountId: string;
+	publicKey: string;
+	recipient?: string;
+	requireFullAccessKey: boolean;
+	validateLimitedAccessKey?: (args: {
+		accountId: AccountId;
+		publicKey: string;
+		recipient?: string;
+	}) => Promise<boolean>;
+}): Promise<void> {
+	const accessKey = await args.near.getAccessKey(args.accountId, args.publicKey);
+	if (!accessKey) {
+		throw new APIError("UNAUTHORIZED", {
+			message: "Unauthorized: Invalid signature",
+			status: 401,
+		});
+	}
+
+	if (args.requireFullAccessKey) {
+		if (accessKey.permission !== "FullAccess") {
+			throw new APIError("UNAUTHORIZED", {
+				message: "Unauthorized: Full access key required",
+				status: 401,
+			});
+		}
+		return;
+	}
+
+	const validateKey = args.validateLimitedAccessKey
+		|| ((validatorArgs: { accountId: AccountId; publicKey: string; recipient?: string }) =>
+			defaultValidateLimitedAccessKey(validatorArgs.accountId, validatorArgs.publicKey, validatorArgs.recipient || args.fallbackRecipient, args.near, accessKey));
+
+	const isValidKey = await validateKey({
+		accountId: args.accountId,
+		publicKey: args.publicKey,
+		recipient: args.recipient,
+	});
+
+	if (!isValidKey) {
+		throw new APIError("UNAUTHORIZED", {
+			message: "Unauthorized: Invalid function call access key",
+			status: 401,
+		});
 	}
 }
 
@@ -658,17 +718,10 @@ export const siwn = (options: SIWNPluginOptions) => {
 						const near = getNear(network);
 						const nonceBytes = hex.decode(nonce);
 
-						const isValid = signedMessage.publicKey.startsWith("ml-dsa-65:")
-							? await verifyMlDsa65Nep413Signature(
-								signedMessage,
-								{ message, recipient, nonce: nonceBytes, callbackUrl },
-								{ near, maxAge: 15 * 60 * 1000 },
-							)
-							: await verifyNep413Signature(
-								signedMessage,
-								{ message, recipient, nonce: nonceBytes, callbackUrl },
-								{ near, maxAge: 15 * 60 * 1000 },
-							);
+						const isValid = await verifyNep413SignatureAny(
+							signedMessage,
+							{ message, recipient, nonce: nonceBytes, callbackUrl },
+						);
 
 						if (!isValid) {
 							throw new APIError("UNAUTHORIZED", {
@@ -686,20 +739,15 @@ export const siwn = (options: SIWNPluginOptions) => {
 
 						const publicKey = signedMessage.publicKey;
 
-						if (!options.requireFullAccessKey && options.validateLimitedAccessKey) {
-							const isValidKey = await options.validateLimitedAccessKey({
-								accountId: accountId,
-								publicKey: publicKey,
-								recipient: options.recipient
-							});
-
-							if (!isValidKey) {
-								throw new APIError("UNAUTHORIZED", {
-									message: "Unauthorized: Invalid function call access key",
-									status: 401,
-								});
-							}
-						}
+						await enforceNep413KeyPolicy({
+							near,
+							fallbackRecipient: getRecipient(network),
+							accountId: accountId,
+							publicKey: publicKey,
+							recipient: options.recipient,
+							requireFullAccessKey: options.requireFullAccessKey ?? false,
+							validateLimitedAccessKey: options.validateLimitedAccessKey,
+						});
 
 						const existingNearAccount: NearAccount | null = await ctx.context.adapter.findOne({
 							model: "nearAccount",
@@ -1034,17 +1082,10 @@ export const siwn = (options: SIWNPluginOptions) => {
 						const near = getNear(network);
 						const nonceBytes = hex.decode(nonce);
 
-						const isValid = signedMessage.publicKey.startsWith("ml-dsa-65:")
-							? await verifyMlDsa65Nep413Signature(
-								signedMessage,
-								{ message, recipient, nonce: nonceBytes, callbackUrl },
-								{ near, maxAge: 15 * 60 * 1000 },
-							)
-							: await verifyNep413Signature(
-								signedMessage,
-								{ message, recipient, nonce: nonceBytes, callbackUrl },
-								{ near, maxAge: 15 * 60 * 1000 },
-							);
+						const isValid = await verifyNep413SignatureAny(
+							signedMessage,
+							{ message, recipient, nonce: nonceBytes, callbackUrl },
+						);
 
 						if (!isValid) {
 							throw new APIError("UNAUTHORIZED", {
@@ -1082,24 +1123,15 @@ export const siwn = (options: SIWNPluginOptions) => {
 							expiresAt: new Date(Date.now() + 15 * 60 * 1000),
 						});
 
-						if (!options.requireFullAccessKey) {
-							const validateKey = options.validateLimitedAccessKey
-								|| ((args: { accountId: string; publicKey: string; recipient?: string }) =>
-									defaultValidateLimitedAccessKey(args.accountId, args.publicKey, args.recipient || getRecipient(network), near));
-
-							const isValidKey = await validateKey({
-								accountId: accountId,
-								publicKey: publicKey,
-								recipient: options.recipient
-							});
-
-							if (!isValidKey) {
-								throw new APIError("UNAUTHORIZED", {
-									message: "Unauthorized: Invalid function call access key",
-									status: 401,
-								});
-							}
-						}
+						await enforceNep413KeyPolicy({
+							near,
+							fallbackRecipient: getRecipient(network),
+							accountId: accountId,
+							publicKey: publicKey,
+							recipient: options.recipient,
+							requireFullAccessKey: options.requireFullAccessKey ?? false,
+							validateLimitedAccessKey: options.validateLimitedAccessKey,
+						});
 
 						let user: User | null = null;
 

--- a/src/near.test.ts
+++ b/src/near.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTestInstance } from "better-auth/test";
 import { siwn } from "./index.js";
 import { siwnClient } from "./client.js";
@@ -1333,5 +1333,89 @@ describe("siwnClient getActions", () => {
 			const json = await res.json();
 			expect(json.success).toBe(true);
 		});
+
+		describe("key policy", () => {
+			it("should accept an ml-dsa-65 function-call access key scoped to the recipient by default", async () => {
+				const { Near } = await import("near-kit");
+				new (Near as any)().getAccessKey.mockImplementation(() =>
+					Promise.resolve({ nonce: 0, permission: { FunctionCall: { receiver_id: MOCK_RECIPIENT, method_names: [] } } }));
+				const { client } = await setup();
+				const body = await makeMlDsa65VerifyBody();
+				const { data, error } = await client.near.verify(body);
+				expect(error).toBeNull();
+				expect(data?.success).toBe(true);
+				expect(data?.token).toBeDefined();
+			});
+		});
+	});
+});
+
+describe("NEP-413 key policy", () => {
+	const FCAK_RECIPIENT = { nonce: 0, permission: { FunctionCall: { receiver_id: MOCK_RECIPIENT, method_names: [] } } };
+	const FCAK_OTHER_CONTRACT = { nonce: 0, permission: { FunctionCall: { receiver_id: "other.contract.near", method_names: [] } } };
+
+	async function setAccessKey(accessKey: unknown) {
+		const { Near } = await import("near-kit");
+		new (Near as any)().getAccessKey.mockImplementation(() => Promise.resolve(accessKey));
+	}
+
+	beforeEach(async () => {
+		const { Near, verifyNep413Signature } = await import("near-kit");
+		new (Near as any)().getAccessKey.mockImplementation(() => Promise.resolve({ nonce: 0, permission: "FullAccess" }));
+		(verifyNep413Signature as any).mockImplementation(() => Promise.resolve(true));
+	});
+
+	afterEach(async () => {
+		const { Near, verifyNep413Signature } = await import("near-kit");
+		new (Near as any)().getAccessKey.mockImplementation(() => Promise.resolve({ nonce: 0, permission: "FullAccess" }));
+		(verifyNep413Signature as any).mockImplementation(() => Promise.resolve(true));
+	});
+
+	it("should accept a function-call access key scoped to the recipient by default", async () => {
+		await setAccessKey(FCAK_RECIPIENT);
+		const { client } = await setup();
+		const { data, error } = await client.near.verify(makeVerifyBody());
+		expect(error).toBeNull();
+		expect(data?.success).toBe(true);
+		expect(data?.token).toBeDefined();
+	});
+
+	it("should reject a function-call access key scoped to another contract by default", async () => {
+		await setAccessKey(FCAK_OTHER_CONTRACT);
+		const { client } = await setup();
+		const { error } = await client.near.verify(makeVerifyBody());
+		expect(error).toBeDefined();
+		expect(error?.status).toBe(401);
+	});
+
+	it("should reject a signing key that does not exist on the claimed account", async () => {
+		await setAccessKey(null);
+		const { client } = await setup();
+		const { error } = await client.near.verify(makeVerifyBody());
+		expect(error).toBeDefined();
+		expect(error?.status).toBe(401);
+	});
+
+	it("should reject a function-call access key when requireFullAccessKey is true", async () => {
+		await setAccessKey(FCAK_RECIPIENT);
+		const { client } = await setup({ requireFullAccessKey: true });
+		const { error } = await client.near.verify(makeVerifyBody());
+		expect(error).toBeDefined();
+		expect(error?.status).toBe(401);
+	});
+
+	it("should accept a full access key when requireFullAccessKey is true", async () => {
+		const { client } = await setup({ requireFullAccessKey: true });
+		const { data, error } = await client.near.verify(makeVerifyBody());
+		expect(error).toBeNull();
+		expect(data?.success).toBe(true);
+	});
+
+	it("should let validateLimitedAccessKey enable keys the default validator would reject", async () => {
+		await setAccessKey(FCAK_OTHER_CONTRACT);
+		const { client } = await setup({ validateLimitedAccessKey: async () => true });
+		const { data, error } = await client.near.verify(makeVerifyBody());
+		expect(error).toBeNull();
+		expect(data?.success).toBe(true);
 	});
 });


### PR DESCRIPTION
Stacked on #77 — fixes the pre-existing key-policy gap surfaced in https://github.com/elliotBraem/better-near-auth/pull/77#issuecomment-5512047774.

## Problem

The SIWN endpoints (`/api/auth/near/verify`, `/api/auth/near/link-account`) delegated the on-chain access-key check to `near-kit`'s `verifyNep413Signature`, which **hard-requires a FullAccess key** whenever a `near` client is passed (both 0.14 and 0.19, `dist/utils/nep413.js`). That check runs *before* the plugin's own `requireFullAccessKey` / `validateLimitedAccessKey` policy, so:

- The documented default (`requireFullAccessKey: false` — "full-access key or function-call key scoped to the recipient") was **unreachable**: FCAK signatures were rejected with `401 Invalid signature`.
- Custom `validateLimitedAccessKey` implementations could only *restrict* (reject FullAccess keys), never *enable* limited keys — for both ed25519 and ml-dsa-65.

## Fix

Signature verification and key policy are now separated:

1. `verifyNep413SignatureAny` verifies the NEP-413 signature only (ed25519 via near-kit **without** the `near` access check, ml-dsa-65 via `@noble/post-quantum`) — also dedupes the identical verify/link-account ternaries.
2. `enforceNep413KeyPolicy` runs uniformly in both endpoints: the signing key must **exist on the claimed account** (defense-in-depth `getAccessKey` preserved, once per request), then:
   - `requireFullAccessKey: true` → FullAccess required (`401 Full access key required` otherwise)
   - `requireFullAccessKey: false` → custom validator, or `defaultValidateLimitedAccessKey` (FullAccess **or** FCAK scoped to the recipient) — accepting the prefetched access key to avoid a second RPC.

`verifyMlDsa65Nep413Signature` drops its internal access-key check (the policy step owns it now), so the PQ path honors the same policy as ed25519.

## Tests

- FCAK scoped to recipient accepted by default (ed25519 + ml-dsa-65)
- FCAK scoped to another contract rejected by default
- Missing key on claimed account rejected
- `requireFullAccessKey: true` rejects FCAK / accepts FAK
- Custom `validateLimitedAccessKey` can enable limited keys

87/87 pass, `tsc --noEmit` clean.