### PR TITLE
refactor: remove production as-any casts and clean up test mock typing

### DIFF
--- a/skills/subaccount/SKILL.md
+++ b/skills/subaccount/SKILL.md
@@ -11,7 +11,7 @@ description: >
 metadata:
   type: core
   library: better-near-auth
-  library_version: "1.8.3"
+  library_version: "1.10.2"
 sources:
   - "elliotBraem/better-near-auth:src/index.ts"
   - "elliotBraem/better-near-auth:src/types.ts"
@@ -413,6 +413,33 @@ siwn({
   relayer: { accountId: "relayer.near", privateKey: "..." },
   secrets: { parentKey: process.env.PARENT_KEY },
   subAccount: { parentAccount: "user.parent.near" },
+});
+```
+
+### MEDIUM Malformed relayerFCAK.allowance or deploy.fromPublished shape
+
+Both are validated at creation time and throw `BetterAuthError` with a clear message instead of failing obscurely inside near-kit:
+
+- `relayerFCAK.allowance` must match `"0.25 NEAR"` or `"1000000 yocto"` format
+- `deploy.fromPublished` requires exactly one of `accountId` or `codeHash` — omitting both throws `"subAccount.deploy.fromPublished requires accountId or codeHash"`
+
+```typescript
+// Wrong: unparseable allowance, fromPublished with neither field
+siwn({
+  subAccount: {
+    parentAccount: "myapp.near",
+    relayerFCAK: { receiverId: "myapp.near", allowance: "0.25NEAR" },
+    deploy: { fromPublished: {} },
+  },
+});
+
+// Correct: formatted allowance, one reference field
+siwn({
+  subAccount: {
+    parentAccount: "myapp.near",
+    relayerFCAK: { receiverId: "myapp.near", allowance: "0.25 NEAR" },
+    deploy: { fromPublished: { accountId: "publisher.near" } },
+  },
 });
 ```
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -354,7 +354,7 @@ export const siwnClient = (config: SIWNClientConfig) => {
 		id: "siwn" as const,
 		$InferServerPlugin: {},
 
-		getAtoms: (_$fetch: BetterFetch) => ({
+		getAtoms: (_$fetch?: BetterFetch) => ({
 			nearState,
 			walletConnected,
 			activeNetwork,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import type { AuthContext } from "@better-auth/core";
 import { BetterAuthError } from "@better-auth/core/error";
 
 import { Near, generateNonce, generateKey, parseKey, verifyNep413Signature, decodeSignedDelegateAction, InMemoryKeyStore } from "near-kit";
-import type { SignedDelegateAction, PrivateKey } from "near-kit";
+import type { SignedDelegateAction, PrivateKey, GlobalContractReference } from "near-kit";
 import { hex, base58, base64 } from "@scure/base";
 import { ml_dsa65 } from "@noble/post-quantum/ml-dsa.js";
 import z from "zod";
@@ -332,6 +332,15 @@ async function defaultValidateLimitedAccessKey(
 }
 
 const ML_DSA_65_KEY_PREFIX = "ml-dsa-65:";
+
+type NearAmount = `${number} NEAR` | `${bigint} yocto`;
+
+type NearFunctionCallKeyPermission = {
+	type: "functionCall";
+	receiverId: string;
+	methodNames?: string[];
+	allowance?: NearAmount;
+};
 const ML_DSA_65_PUBLIC_KEY_LENGTH = 1952;
 const NEP413_TAG = 2147484061;
 
@@ -1701,7 +1710,7 @@ const { parentAccount, subAccountAvailable } = resolveParentAccount(subAccountCf
 					}
 
 					if (subAccountCfg?.addRelayerFCAK !== false && subAccountCfg?.relayerFCAK && rState) {
-						const fcakPermission: { type: "functionCall"; receiverId: string; methodNames?: string[]; allowance?: string } = {
+						const fcakPermission: NearFunctionCallKeyPermission = {
 							type: "functionCall",
 							receiverId: subAccountCfg.relayerFCAK.receiverId,
 						};
@@ -1709,9 +1718,13 @@ const { parentAccount, subAccountAvailable } = resolveParentAccount(subAccountCf
 							fcakPermission.methodNames = subAccountCfg.relayerFCAK.methodNames;
 						}
 						if (subAccountCfg.relayerFCAK.allowance) {
-							fcakPermission.allowance = subAccountCfg.relayerFCAK.allowance as `${number} NEAR` | `${bigint} yocto`;
+							const raw = subAccountCfg.relayerFCAK.allowance;
+							if (!/^\d+(\.\d+)? NEAR$/.test(raw) && !/^\d+ yocto$/.test(raw)) {
+								throw new BetterAuthError(`subAccount.relayerFCAK.allowance must be formatted like "1 NEAR" or "1000 yocto", got "${raw}"`);
+							}
+							fcakPermission.allowance = raw as NearAmount;
 						}
-						txBuilder.addKey(rState.publicKey, fcakPermission as any);
+						txBuilder.addKey(rState.publicKey, fcakPermission);
 					}
 
 					txBuilder.transfer(newAccountId, minDeposit as `${number} NEAR`);
@@ -1719,9 +1732,18 @@ const { parentAccount, subAccountAvailable } = resolveParentAccount(subAccountCf
 					if (subAccountCfg?.deploy) {
 						if ("wasm" in subAccountCfg.deploy) {
 							txBuilder = txBuilder.deployContract(newAccountId, subAccountCfg.deploy.wasm);
-						} else if ("fromPublished" in subAccountCfg.deploy) {
-							txBuilder = txBuilder.deployFromPublished(subAccountCfg.deploy.fromPublished as any);
+					} else if ("fromPublished" in subAccountCfg.deploy) {
+						const { accountId, codeHash } = subAccountCfg.deploy.fromPublished;
+						const reference: GlobalContractReference | null = accountId !== undefined
+							? { accountId }
+							: codeHash !== undefined
+								? { codeHash }
+								: null;
+						if (!reference) {
+							throw new BetterAuthError("subAccount.deploy.fromPublished requires accountId or codeHash");
 						}
+						txBuilder = txBuilder.deployFromPublished(reference);
+					}
 					}
 
 					if (subAccountCfg?.init) {

--- a/src/near.test.ts
+++ b/src/near.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { getTestInstance } from "better-auth/test";
-import { siwn } from "./index.js";
+import { siwn, type SIWNPluginOptions } from "./index.js";
 import { siwnClient } from "./client.js";
 import { SUB_ACCOUNT_LABEL_REGEX } from "./types.js";
 import { hex, base58, base64 } from "@scure/base";
@@ -33,6 +33,11 @@ function makeUniqueNonce(): Uint8Array {
 	for (let i = 0; i < 32; i++) nonce[i] = (i + 1) ^ (nonceCounter & 0xff);
 	return nonce;
 }
+
+const getNearAccessKeyMock = async (): Promise<Mock> => {
+	const { Near } = await import("near-kit");
+	return (new Near() as unknown as { getAccessKey: Mock }).getAccessKey;
+};
 
 vi.mock("near-kit", () => {
 	const mockNearInstance = {
@@ -191,7 +196,7 @@ async function setup(overrides?: {
 	requireFullAccessKey?: boolean;
 	relayer?: any;
 	getProfile?: any;
-	validateLimitedAccessKey?: any;
+	validateLimitedAccessKey?: SIWNPluginOptions["validateLimitedAccessKey"];
 	subAccount?: any;
 	secrets?: { parentKey?: string };
 }) {
@@ -297,7 +302,7 @@ describe("siwn plugin", () => {
 
 		it("should reject an signed message with mismatched accountId", async () => {
 			const { verifyNep413Signature } = await import("near-kit");
-			(verifyNep413Signature as any).mockResolvedValueOnce(false);
+			vi.mocked(verifyNep413Signature).mockResolvedValueOnce(false);
 			const { client } = await setup();
 			const { error } = await client.near.verify(makeVerifyBody());
 			expect(error).toBeDefined();
@@ -305,7 +310,7 @@ describe("siwn plugin", () => {
 
 		it("should pass callbackUrl through to NEP-413 verification (redirect wallets)", async () => {
 			const { verifyNep413Signature } = await import("near-kit");
-			(verifyNep413Signature as any).mockClear();
+			vi.mocked(verifyNep413Signature).mockClear();
 			const { client } = await setup();
 
 			const { data, error } = await client.near.verify({
@@ -315,7 +320,7 @@ describe("siwn plugin", () => {
 
 			expect(error).toBeNull();
 			expect(data?.success).toBe(true);
-			const params = (verifyNep413Signature as any).mock.calls.at(-1)?.[1];
+			const params = vi.mocked(verifyNep413Signature).mock.calls.at(-1)?.[1];
 			expect(params?.callbackUrl).toBe("myapp://callback/success");
 		});
 
@@ -778,7 +783,7 @@ describe("siwn plugin", () => {
 
 			// Force ensureRelayer to throw on the next fresh ephemeral init by making generateKey throw.
 			const { generateKey } = await import("near-kit");
-			const generateSpy = (generateKey as any);
+			const generateSpy = vi.mocked(generateKey);
 			const originalImpl = generateSpy.getMockImplementation() ?? (() => ({ publicKey: { data: new Uint8Array(32).fill(1), toString: () => MOCK_GENERATED_PUBLIC_KEY }, secretKey: MOCK_GENERATED_SECRET_KEY, sign: vi.fn(), signNep413Message: vi.fn() }));
 			generateSpy.mockImplementation(() => {
 				throw new Error("Forced key gen failure: simulated runtime DB/secret error");
@@ -1140,7 +1145,7 @@ describe("siwnClient getActions", () => {
 					},
 				},
 			});
-			plugin.getAtoms(undefined as unknown as Parameters<typeof plugin.getAtoms>[0]).nearState.set({
+			plugin.getAtoms().nearState.set({
 				accountId: "charlie.near",
 				publicKey: "ed25519:live",
 				networkId: "mainnet",
@@ -1202,8 +1207,8 @@ describe("siwnClient getActions", () => {
 
 			await actions.near.setPrimaryAccount({ accountId: "bob.near", network: "mainnet" });
 
-			expect((store.notify as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith("$sessionSignal");
-			expect(plugin.getAtoms(undefined as unknown as Parameters<typeof plugin.getAtoms>[0]).nearState.get()).toEqual({
+			expect(store.notify).toHaveBeenCalledWith("$sessionSignal");
+			expect(plugin.getAtoms().nearState.get()).toEqual({
 				accountId: "bob.near",
 				publicKey: "ed25519:bob",
 				networkId: "mainnet",
@@ -1276,8 +1281,8 @@ describe("siwnClient getActions", () => {
 
 		it("should accept a valid ml-dsa-65 signed message and create a session", async () => {
 			const { verifyNep413Signature } = await import("near-kit");
-			(verifyNep413Signature as any).mockClear();
-			(verifyNep413Signature as any).mockImplementation(() => {
+			vi.mocked(verifyNep413Signature).mockClear();
+			vi.mocked(verifyNep413Signature).mockImplementation(() => {
 				throw new Error("Only Ed25519 keys are supported for NEP-413");
 			});
 
@@ -1288,7 +1293,7 @@ describe("siwnClient getActions", () => {
 			expect(decoded.length).toBe(MLDSA65_PUBLIC_KEY_LENGTH);
 
 			const { data, error } = await client.near.verify(body);
-			expect(verifyNep413Signature as any).not.toHaveBeenCalled();
+			expect(vi.mocked(verifyNep413Signature)).not.toHaveBeenCalled();
 			expect(error).toBeNull();
 			expect(data?.success).toBe(true);
 			expect(data?.token).toBeDefined();
@@ -1304,8 +1309,8 @@ describe("siwnClient getActions", () => {
 
 		it("should accept an ml-dsa-65 signed message on the link-account endpoint", async () => {
 			const { verifyNep413Signature } = await import("near-kit");
-			(verifyNep413Signature as any).mockClear();
-			(verifyNep413Signature as any).mockImplementation(() => {
+			vi.mocked(verifyNep413Signature).mockClear();
+			vi.mocked(verifyNep413Signature).mockImplementation(() => {
 				throw new Error("Only Ed25519 keys are supported for NEP-413");
 			});
 
@@ -1329,7 +1334,7 @@ describe("siwnClient getActions", () => {
 				body: JSON.stringify(body),
 			});
 			expect(res.status).toBe(200);
-			expect(verifyNep413Signature as any).not.toHaveBeenCalled();
+			expect(vi.mocked(verifyNep413Signature)).not.toHaveBeenCalled();
 			const json = await res.json();
 			expect(json.success).toBe(true);
 		});
@@ -1337,7 +1342,7 @@ describe("siwnClient getActions", () => {
 		describe("key policy", () => {
 			it("should accept an ml-dsa-65 function-call access key scoped to the recipient by default", async () => {
 				const { Near } = await import("near-kit");
-				new (Near as any)().getAccessKey.mockImplementation(() =>
+				(await getNearAccessKeyMock()).mockImplementation(() =>
 					Promise.resolve({ nonce: 0, permission: { FunctionCall: { receiver_id: MOCK_RECIPIENT, method_names: [] } } }));
 				const { client } = await setup();
 				const body = await makeMlDsa65VerifyBody();
@@ -1355,20 +1360,19 @@ describe("NEP-413 key policy", () => {
 	const FCAK_OTHER_CONTRACT = { nonce: 0, permission: { FunctionCall: { receiver_id: "other.contract.near", method_names: [] } } };
 
 	async function setAccessKey(accessKey: unknown) {
-		const { Near } = await import("near-kit");
-		new (Near as any)().getAccessKey.mockImplementation(() => Promise.resolve(accessKey));
+		(await getNearAccessKeyMock()).mockImplementation(() => Promise.resolve(accessKey));
 	}
 
 	beforeEach(async () => {
-		const { Near, verifyNep413Signature } = await import("near-kit");
-		new (Near as any)().getAccessKey.mockImplementation(() => Promise.resolve({ nonce: 0, permission: "FullAccess" }));
-		(verifyNep413Signature as any).mockImplementation(() => Promise.resolve(true));
+		const { verifyNep413Signature } = await import("near-kit");
+		(await getNearAccessKeyMock()).mockImplementation(() => Promise.resolve({ nonce: 0, permission: "FullAccess" }));
+		vi.mocked(verifyNep413Signature).mockImplementation(() => Promise.resolve(true));
 	});
 
 	afterEach(async () => {
-		const { Near, verifyNep413Signature } = await import("near-kit");
-		new (Near as any)().getAccessKey.mockImplementation(() => Promise.resolve({ nonce: 0, permission: "FullAccess" }));
-		(verifyNep413Signature as any).mockImplementation(() => Promise.resolve(true));
+		const { verifyNep413Signature } = await import("near-kit");
+		(await getNearAccessKeyMock()).mockImplementation(() => Promise.resolve({ nonce: 0, permission: "FullAccess" }));
+		vi.mocked(verifyNep413Signature).mockImplementation(() => Promise.resolve(true));
 	});
 
 	it("should accept a function-call access key scoped to the recipient by default", async () => {


### PR DESCRIPTION
Stacked on #79 (type-polish follow-up from the review pass).

## Production casts eliminated

- **`txBuilder.addKey(..., fcakPermission as any)`** → the permission object is now typed as near-kit's function-call shape (`NearFunctionCallKeyPermission`), and the `allowance` string is runtime-validated (`/^\d+(\.\d+)? NEAR$/` or `/^\d+ yocto$/`, otherwise `BetterAuthError`) before a single honest assertion — replacing both the `as any` and the unverifiable template-literal cast.
- **`deployFromPublished(subAccountCfg.deploy.fromPublished as any)`** → explicitly maps to near-kit's `GlobalContractReference` (`accountId` first, then `codeHash`, matching near-kit's own `"accountId" in reference` precedence) and throws a clear `BetterAuthError` when neither is set — previously an obscure runtime failure.

## Test cleanup (`near.test.ts`: 31 `as any` → 10, all intentional)

- `vi.mocked(verifyNep413Signature)` / `vi.mocked(generateKey)` replace mock casts
- `getNearAccessKeyMock()` helper — one typed cast instead of `new (Near as any)()` × 4
- `plugin.getAtoms()` (param is now optional) replaces `undefined as unknown as ...`
- `store.notify` assertion no longer needs a cast
- `setup({ validateLimitedAccessKey })` uses `SIWNPluginOptions["validateLimitedAccessKey"]`
- Remaining 10 are honest invalid-input / dynamic-field casts (e.g. `{ accountId: "INVALID" } as any`, `(user as any).email`)

`client.ts` keeps one idiomatic cast: `typeof (globalThis as any).window`.

87/87 tests pass, `tsc --noEmit` clean.