### PR TITLE
fix(examples): reactive near account reads; remove dead useRelayHistory

### DIFF
--- a/examples/auth.everything.dev/ui/src/app.ts
+++ b/examples/auth.everything.dev/ui/src/app.ts
@@ -96,7 +96,6 @@ export {
   sessionQueryKey,
   sessionQueryOptions,
   useAuthClient,
-  useRelayHistory,
 } from "./lib/auth";
 
 import type {

--- a/examples/auth.everything.dev/ui/src/lib/auth.ts
+++ b/examples/auth.everything.dev/ui/src/lib/auth.ts
@@ -7,7 +7,6 @@
 
 import { apiKeyClient } from "@better-auth/api-key/client";
 import { passkeyClient } from "@better-auth/passkey/client";
-import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
 import {
   adminClient,
@@ -17,7 +16,6 @@ import {
   phoneNumberClient,
 } from "better-auth/client/plugins";
 import { createAuthClient as createBetterAuthClient } from "better-auth/react";
-import type { RelayedTransactionT } from "better-near-auth";
 import { siwnClient } from "better-near-auth/client";
 import type { ClientRuntimeConfig } from "everything-dev/types";
 import { getRuntimeConfig } from "everything-dev/ui/runtime";
@@ -162,16 +160,4 @@ export function sessionQueryOptions(authClient: AuthClient, initialSession?: Ses
   return initialSession === undefined
     ? baseOptions
     : { ...baseOptions, initialData: initialSession };
-}
-
-export function useRelayHistory(session: SessionData | null | undefined, authClient: AuthClient) {
-  return useQuery({
-    queryKey: ["relay-history"],
-    queryFn: async (): Promise<RelayedTransactionT[]> => {
-      const res = await authClient.near.relayHistory();
-      return res?.data?.transactions ?? [];
-    },
-    enabled: !!session,
-    refetchInterval: 2000,
-  });
 }

--- a/examples/browser-2-server/apps/web/src/routes/_layout/dashboard.tsx
+++ b/examples/browser-2-server/apps/web/src/routes/_layout/dashboard.tsx
@@ -1,4 +1,5 @@
 import { authClient } from "@/lib/auth-client";
+import { useNearAccountId } from "better-near-auth/react";
 import { getNearAccountId, getLinkedProviders } from "@/lib/auth-utils";
 import { orpc } from "@/utils/orpc";
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
@@ -478,7 +479,7 @@ function AccountLinkingCard({ linkedAccounts, nearAccountId }: {
   const [isProcessingNear, setIsProcessingNear] = useState(false);
   const [isUnlinking, setIsUnlinking] = useState<string | null>(null);
 
-  const walletAccountId = authClient.near.getAccountId();
+  const walletAccountId = useNearAccountId(authClient);
   const accounts = linkedAccounts;
 
   const invalidateAccounts = () => {
@@ -777,7 +778,7 @@ function GuestbookCard({ initialGreeting }: { initialGreeting?: string }) {
       if (!accountId) throw new Error("Not authenticated");
       const connected = await authClient.near.ensureConnected();
       if (!connected) throw new Error("Wallet connection required");
-      return authClient.near.client
+      return authClient.near.getNearClient()
         .transaction(accountId)
         .functionCall(GUESTBOOK_CONTRACT, "set_greeting", { greeting: text }, {
           gas: Gas.Tgas(30),


### PR DESCRIPTION
Closes **ticket 01-relayer-wallet-restore**. Stacked on #78 (uses `better-near-auth/react`).

## Ticket items

| Item | Resolution |
|---|---|
| "session fallback for useNearAccount()" | browser-2-server's `dashboard.tsx` now reads the NEAR account via `useNearAccountId(authClient)` — reactive, with the session fallback, so identity renders before NearConnect re-initializes (previously a non-reactive `getAccountId()` render read that could stay stale after reload) |
| "only ensureConnected() at signature time" | Verified already true — the sole example call site is inside the guestbook sign mutation; nothing prompts on mount. No change needed |
| "remove dead useRelayHistory (2s polling, unused)" | Removed from `auth.everything.dev` (`lib/auth.ts` + `app.ts` re-export) — confirmed zero component usage. ⚠️ browser-2-server has its **own** copy which is *live* (used by `RelayFeed`) — intentionally left alone |

## Bonus

Fixed a pre-existing typecheck break in the same mutation: `authClient.near.client` → `authClient.near.getNearClient()` (the action was renamed upstream; the example was never updated). `tsc --noEmit` now passes in browser-2-server web.

## Note on the remaining root-cause half

`nearState` staying in-memory for *signing* state is accepted per the ticket — display identity comes from the session (`session.user.nearAccount` via #77/#78), and NearConnect only re-initializes lazily for signing.